### PR TITLE
Rename import unlock button "Unlock"

### DIFF
--- a/src/main/java/org/sigmah/client/ui/presenter/importation/ImportationPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/importation/ImportationPresenter.java
@@ -417,7 +417,7 @@ public class ImportationPresenter extends AbstractPagePresenter<ImportationPrese
 	}
 	
 	private Button renderUnlockButton(final ImportDetails model) {
-		final Button unlockButton = Forms.button(I18N.CONSTANTS.importButtonConfirmDetails());
+		final Button unlockButton = Forms.button(I18N.CONSTANTS.projectCoreUnlockButton());
 		
 		unlockButton.addSelectionListener(new SelectionListener<ButtonEvent>() {
 

--- a/src/main/java/org/sigmah/client/ui/view/project/dashboard/LinkedProjectsColumnsProvider.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/dashboard/LinkedProjectsColumnsProvider.java
@@ -106,7 +106,11 @@ final class LinkedProjectsColumnsProvider extends LinkedProjectsAbstractProvider
 		// Amount.
 		final ColumnConfig amountColumn = new ColumnConfig();
 		amountColumn.setId(ProjectFundingDTO.PERCENTAGE);
-		amountColumn.setHeaderHtml(I18N.CONSTANTS.projectFinances() + " (" + I18N.CONSTANTS.currencyEuro() + ')');
+		if (this.projectType == LinkedProjectType.FUNDING_PROJECT) {
+			amountColumn.setHeaderHtml(I18N.CONSTANTS.projectFinances() + " (" + I18N.CONSTANTS.currencyEuro() + ')');
+		} else {
+			amountColumn.setHeaderHtml(I18N.CONSTANTS.projectFundedBy() + " (" + I18N.CONSTANTS.currencyEuro() + ')');
+		}
 		amountColumn.setWidth(120);
 
 		// Percentage.


### PR DESCRIPTION
Commit made as pull request, because unsure of all consequences of this change.
Once the user has clicked on the "Unlock" button, will be button be renamed "Confirm import details" as it should?

If too much problem with this pull request, not problem to reject it.
