### PR TITLE
Fixed the edition of existing flexible elements (fixes #849)

### DIFF
--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/EditFlexibleElementAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/EditFlexibleElementAdminPresenter.java
@@ -1251,7 +1251,11 @@ public class EditFlexibleElementAdminPresenter extends AbstractPagePresenter<Edi
 		// Common properties.
 		// --
 
-		final LogicalElementType logicalElementType = TypeModel.getType(view.getTypeField().getValue());
+		final LogicalElementType logicalElementType = flexibleElement != null ? 
+				// BUGFIX #849: When disabled, GXT combo box can't be set and thus return null.
+				// So instead of using the value of the combo box, the type is set from the edited element.
+				LogicalElementTypes.of(flexibleElement) : 
+				TypeModel.getType(view.getTypeField().getValue());
 		final ElementTypeEnum type = logicalElementType.toElementTypeEnum();
 		final LayoutGroupDTO group = view.getLayoutGroupField().getValue();
 		final Integer order = ClientUtils.getInteger(view.getOrderField().getValue().intValue());


### PR DESCRIPTION
When editing a flexible element, the type of the element is retrieved from the given element instead of the one displayed in the combo box because when disabled the combo box always return null.
