### PR TITLE
720: Importation scheme of Administration tab title renaming fixed

### DIFF
--- a/src/main/java/org/sigmah/client/page/Page.java
+++ b/src/main/java/org/sigmah/client/page/Page.java
@@ -316,6 +316,8 @@ public enum Page implements IsSerializable {
 				return I18N.CONSTANTS.adminboard();
 			case ADMIN_PARAMETERS:
 				return I18N.CONSTANTS.adminboard();
+			case ADMIN_IMPORTATION_SCHEME:
+				return I18N.CONSTANTS.adminboard();
 			case CREATE_PROJECT:
 				return I18N.CONSTANTS.createProject();
 			default:


### PR DESCRIPTION
"Importation scheme" part of Administration now consistent with other tabs with "Administration" as tabtitle. Fixes [#720](http://www.sigmah.org/issues/view.php?id=720)