### PR TITLE
issue #168 : disabled report creation menu item for closed phase

### DIFF
--- a/src/main/java/org/sigmah/client/ui/presenter/project/ProjectReportsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/ProjectReportsPresenter.java
@@ -267,7 +267,7 @@ public class ProjectReportsPresenter extends AbstractProjectPresenter<ProjectRep
 				item.setTitle(I18N.CONSTANTS.flexibleElementFilesListAddErrorPhaseClosed());
 
 				item.setActiveStyle("trace-action-disabled");
-				item.setStyleAttribute("background-color", "lightgray");
+				item.setStyleAttribute("opacity", "0.4" );
 				item.setStyleAttribute("cursor", "default");
 
 			} else if (element.getPhase().equals(getProject().getCurrentPhase())) {

--- a/src/main/java/org/sigmah/client/ui/presenter/project/ProjectReportsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/ProjectReportsPresenter.java
@@ -266,6 +266,10 @@ public class ProjectReportsPresenter extends AbstractProjectPresenter<ProjectRep
 				item.setIcon(IconImageBundle.ICONS.close());
 				item.setTitle(I18N.CONSTANTS.flexibleElementFilesListAddErrorPhaseClosed());
 
+				item.setActiveStyle("trace-action-disabled");
+				item.setStyleAttribute("background-color", "lightgray");
+				item.setStyleAttribute("cursor", "default");
+
 			} else if (element.getPhase().equals(getProject().getCurrentPhase())) {
 
 				// --


### PR DESCRIPTION
#0000168 : "In the "Reports & documents" sub-tab, when the user clicks on the "New report" button, a drop-down menu appears and the report elements belonging to closed phases should appear as disabled.
Currently, they appear as enabled, but when the user clicks on it, nothing happen."
Hi, 
I fixed the issue by changing the style of the items which have closed phases.
Earlier, on hovering over a report from a closed phase, it turned orange, and appeared to be enabled.
![image](https://cloud.githubusercontent.com/assets/15144957/24079189/6c4e1196-0ca8-11e7-8053-9aea314e4bca.png)

Now, its background is gray and hovering over it does not change the color or cursor style.
![image](https://cloud.githubusercontent.com/assets/15144957/24079249/4e6e3754-0ca9-11e7-878b-9502359374b9.png)

I hope this is enough for showing it is disabled.