### PR TITLE
Refractoring: removing GIN dependency injection and replacing by defered binding. Issue #1080

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<!-- =========================================================================================== -->
 	<!-- -->
@@ -10,8 +11,8 @@
 
 	<groupId>org.sigmah</groupId>
 	<artifactId>sigmah</artifactId>
-	<!-- Any change of version here should also be reported manually client-side in 
-		public static final String VERSION of /src/main/java/org/sigmah/client/Sigmah.java  -->
+	<!-- Any change of version here should also be reported manually client-side 
+		in public static final String VERSION of /src/main/java/org/sigmah/client/Sigmah.java -->
 	<version>2.2-SNAPSHOT</version>
 
 	<packaging>war</packaging>
@@ -47,8 +48,8 @@
 	<!-- =========================================================================================== -->
 
 	<developers>
-		<!-- Representatives of the two organizations co-authors of Sigmah. For
-		full developers list, see: https://github.com/sigmah-dev/sigmah/graphs/contributors). -->
+		<!-- Representatives of the two organizations co-authors of Sigmah. For 
+			full developers list, see: https://github.com/sigmah-dev/sigmah/graphs/contributors). -->
 		<developer>
 			<id>groupe.urd</id>
 			<name>Groupe URD</name>
@@ -130,7 +131,7 @@
 	<!-- =========================================================================================== -->
 
 	<properties>
-	
+
 		<!-- ========= [ PROJECT PROPERTIES. ] ========= -->
 
 		<!-- JDK. -->
@@ -195,15 +196,17 @@
 		<itext-rtf.version>2.1.7</itext-rtf.version>
 		<quartz.version>1.5.2</quartz.version>
 		<gson.version>2.6.1</gson.version>
-		
+
 		<!-- ========= [ DEFAULT PROFILES PROPERTIES. ] ========= -->
-		
+
 		<!-- Logger properties. -->
 
-		<log.pattern>[%-5level] {%d{dd/MM/yyyy HH:mm:ss.SSS}} [%thread] %logger{35} - %msg%n</log.pattern>
+		<log.pattern>[%-5level] {%d{dd/MM/yyyy HH:mm:ss.SSS}} [%thread]
+			%logger{35} - %msg%n</log.pattern>
 		<log.level>ERROR</log.level> <!-- Available levels: ALL, TRACE, DEBUG, INFO, WARN, ERROR, OFF. -->
 
-		<!-- Default database access properties, shared by both Flyway and Hibernate (may be override in profiles) -->
+		<!-- Default database access properties, shared by both Flyway and Hibernate 
+			(may be override in profiles) -->
 
 		<sigmah.database.url>jdbc:postgresql://localhost:5432/sigmah</sigmah.database.url>
 		<sigmah.database.user>sigmah</sigmah.database.user>
@@ -219,7 +222,7 @@
 		<hibernate.connection.url>${sigmah.database.url}</hibernate.connection.url>
 		<hibernate.connection.username>${sigmah.database.user}</hibernate.connection.username>
 		<hibernate.connection.password>${sigmah.database.password}</hibernate.connection.password>
-		
+
 		<!-- JDBC pool properties. -->
 
 		<jdbc.pool.min_size>1</jdbc.pool.min_size>
@@ -249,7 +252,7 @@
 		<mail.contentType>text/html</mail.contentType>
 
 		<mail.support.to>support@sigmah.org</mail.support.to>
-		
+
 		<!-- Maps API properties. -->
 
 		<maps.key>ABQIAAAAaKyZGjYsJ9quclBfsnGc-xRxtna0S6DNUYSvLTUdQl9eB6x9_xQH4P0V3CSFEY_MypecLWSdS3Q8IQ</maps.key>
@@ -297,7 +300,7 @@
 			<version>${gwt.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		
+
 		<!-- GWT-MAPS -->
 		<dependency>
 			<groupId>com.google.gwt.google-apis</groupId>
@@ -311,7 +314,7 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.gwtopenmaps.openlayers</groupId>
 			<artifactId>gwt-openlayers-client</artifactId>
@@ -389,12 +392,8 @@
 		</dependency>
 
 		<!-- GIN -->
-		<dependency>
-			<groupId>com.google.gwt.inject</groupId>
-			<artifactId>gin</artifactId>
-			<version>${gin.version}</version>
-			<scope>provided</scope>
-		</dependency>
+		<!-- <dependency> <groupId>com.google.gwt.inject</groupId> <artifactId>gin</artifactId> 
+			<version>${gin.version}</version> <scope>provided</scope> </dependency> -->
 
 		<!-- GXT -->
 		<dependency>
@@ -409,7 +408,7 @@
 			<groupId>postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<version>${jdbc-driver-postgresql.version}</version>
-                        <scope>runtime</scope>
+			<scope>runtime</scope>
 		</dependency>
 
 		<!-- HIBERNATE -->
@@ -438,7 +437,7 @@
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>
 			<version>${hibernate-validator.version}</version>
-                        <scope>runtime</scope>
+			<scope>runtime</scope>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>
@@ -450,7 +449,7 @@
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-c3p0</artifactId>
 			<version>${hibernate-c3p0.version}</version>
-                        <scope>runtime</scope>
+			<scope>runtime</scope>
 		</dependency>
 
 		<!-- COMMONS -->
@@ -515,7 +514,7 @@
 			<artifactId>simple-odf</artifactId>
 			<version>${odf.version}</version>
 		</dependency>
-                <dependency>
+		<dependency>
 			<groupId>org.apache.odftoolkit</groupId>
 			<artifactId>odfdom-java</artifactId>
 			<version>0.8.8-incubating</version>
@@ -637,8 +636,8 @@
 							<url>http\://www.urd.org</url>
 						</manager>
 					</managers>
-					<!-- Maven property: ${sigmah.version.partners} Available roles: (developer,
-					ergonomist, designer). -->
+					<!-- Maven property: ${sigmah.version.partners} Available roles: (developer, 
+						ergonomist, designer). -->
 					<partners>
 						<partner>
 							<name>Netapsys</name>
@@ -691,7 +690,7 @@
 							<name>Denis Colliot</name>
 							<email>denis.colliot@gmail.com</email>
 						</developer>
- 						<developer>
+						<developer>
 							<name>tdegivry</name>
 							<email>tde@atolcd.com</email>
 						</developer>
@@ -747,76 +746,76 @@
 					<contributors>
 						<contributor>
 							<name>Alan Beuret</name>
-							<!--<email>beuretalan@gmail.com</email>-->
+							<!--<email>beuretalan@gmail.com</email> -->
 						</contributor>
 						<contributor>
 							<name>Mathilde Beziau</name>
-							<!--<email>Mathilde.Beziau@croix-rouge.fr</email>-->
+							<!--<email>Mathilde.Beziau@croix-rouge.fr</email> -->
 						</contributor>
 						<contributor>
 							<name>Jean-Christophe Brard</name>
 						</contributor>
 						<contributor>
 							<name>Fadoi Chaouki</name>
-							<!--<email>fadoichaouki@hotmail.fr</email>-->
+							<!--<email>fadoichaouki@hotmail.fr</email> -->
 						</contributor>
 						<contributor>
 							<name>Julien Carlier</name>
-							<!--<email>jcarlier@urd.org</email>-->
+							<!--<email>jcarlier@urd.org</email> -->
 						</contributor>
 						<contributor>
 							<name>Salomé Cousinié</name>
 						</contributor>
 						<contributor>
 							<name>Emeline Dupont-Huin</name>
-							<!--<email>emeline.dupont-huin@medecinsdumonde.net</email>-->
+							<!--<email>emeline.dupont-huin@medecinsdumonde.net</email> -->
 						</contributor>
 						<contributor>
 							<name>Mathilde Guilment</name>
-							<!--<email>mathilde.guilment@gmail.com</email>-->
+							<!--<email>mathilde.guilment@gmail.com</email> -->
 						</contributor>
 						<contributor>
 							<name>Philomène Maigron</name>
 						</contributor>
 						<contributor>
 							<name>Oussama Mojahed</name>
-							<!--<email>omojahed@ideia.fr</email>-->
+							<!--<email>omojahed@ideia.fr</email> -->
 						</contributor>
 						<contributor>
 							<name>Juan Pablo Rodríguez Portugués</name>
-							<!--<email>cachomero@hotmail.com</email>-->
+							<!--<email>cachomero@hotmail.com</email> -->
 						</contributor>
 						<contributor>
 							<name>Laura Perchat</name>
-							<!--<email>l.perchat.lp@gmail.com</email>-->
+							<!--<email>l.perchat.lp@gmail.com</email> -->
 						</contributor>
 						<contributor>
 							<name>Astrid Renet</name>
-							<!--<email>astrid.renet@gmail.com</email>-->
+							<!--<email>astrid.renet@gmail.com</email> -->
 						</contributor>
 						<contributor>
 							<name>Pierrick Rumel</name>
-							<!--<email>pierrick.rumel@gmail.com</email>-->
+							<!--<email>pierrick.rumel@gmail.com</email> -->
 						</contributor>
 						<contributor>
 							<name>Olivier Sarrat</name>
-							<!--<email>osarrat@urd.org</email>-->
+							<!--<email>osarrat@urd.org</email> -->
 						</contributor>
 						<contributor>
 							<name>Flora Soussi</name>
-							<!--<email>flo.soussi@hotmail.fr</email>-->
+							<!--<email>flo.soussi@hotmail.fr</email> -->
 						</contributor>
 						<contributor>
 							<name>Etienne Sutherland</name>
-							<!--<email>esutherland@urd.org</email>-->
+							<!--<email>esutherland@urd.org</email> -->
 						</contributor>
 						<contributor>
 							<name>Pierre van Male</name>
-							<!--<email>vmalep@gmail.com</email>-->
+							<!--<email>vmalep@gmail.com</email> -->
 						</contributor>
 						<contributor>
 							<name>Edmond Wach</name>
-							<!--<email>edmond.wach@yahoo.fr</email>-->
+							<!--<email>edmond.wach@yahoo.fr</email> -->
 						</contributor>
 					</contributors>
 				</configuration>
@@ -931,8 +930,10 @@
 					</i18nMessagesBundles>
 					<!-- For gwt:run command. -->
 					<runTarget>/</runTarget>
+					<localWorkers>4</localWorkers>
 					<module>org.sigmah.Sigmah</module>
-					<extraJvmArgs>-Xmx1G -Xss256M -XX:PermSize=256M -Djava.io.tmpdir=${project.build.directory}</extraJvmArgs>
+					<extraJvmArgs>-Xmx1G -Xss512M -XX:PermSize=256M
+						-Djava.io.tmpdir=${project.build.directory}</extraJvmArgs>
 				</configuration>
 			</plugin>
 
@@ -975,8 +976,8 @@
 
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings
-				only. It has no influence on the Maven build itself. -->
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>
@@ -1028,11 +1029,11 @@
 		<connection>scm:git:https://github.com/sigmah-dev/sigmah.git</connection>
 		<developerConnection>scm:git:git@github.com:sigmah-dev/sigmah.git</developerConnection>
 		<url>https://github.com/sigmah-dev/sigmah</url>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 
 	<profiles>
-		
+
 		<!-- ========= [ LOCAL DEVELOPMENT ENVIRONMENT. ] ========= -->
 
 		<profile>
@@ -1048,7 +1049,7 @@
 				<!-- Hibernate properties. -->
 
 				<hibernate.show_sql>true</hibernate.show_sql>
-				
+
 				<!-- Mailer properties. -->
 
 				<mail.from.name>Sigmah - DEV</mail.from.name>
@@ -1068,81 +1069,107 @@
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>gwt-maven-plugin</artifactId>
 						<version>${gwt-maven-plugin.version}</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>compile</goal>
+									<goal>test</goal>
+									<goal>i18n</goal>
+								</goals>
+							</execution>
+						</executions>
 						<configuration>
+							<logLevel>${gwt.logLevel}</logLevel>
+							<gwtVersion>${gwt.version}</gwtVersion>
+							<webappDirectory>${webapp.directory}</webappDirectory>
+							<hostedWebapp>${webapp.directory}</hostedWebapp>
+							<generateDirectory>${project.build.directory}/generated-sources/java</generateDirectory>
+							<workDir>${project.build.directory}/gwt-workDir</workDir>
+							<i18nConstantsBundles>
+								<i18nConstantsBundle>${project.groupId}.client.i18n.UIConstants</i18nConstantsBundle>
+							</i18nConstantsBundles>
+							<i18nMessagesBundles>
+								<i18nMessagesBundle>${project.groupId}.client.i18n.UIMessages</i18nMessagesBundle>
+							</i18nMessagesBundles>
+							<!-- For gwt:run command. -->
+							<runTarget>/</runTarget>
+							<localWorkers>4</localWorkers>
+							<draftCompile>true</draftCompile>
 							<module>org.sigmah.SigmahDev</module>
+							<extraJvmArgs>-Xmx1G -Xss256M -Djava.io.tmpdir=${project.build.directory}</extraJvmArgs>
 						</configuration>
 					</plugin>
 				</plugins>
 			</build>
 		</profile>
-		        
+
 		<!-- ========= [ HANDICAP INTERNATIONAL SPECIAL VERSION. ] ========= -->
-                <profile>
-                        <id>sigmah-custom-handicapinternational</id>
+		<profile>
+			<id>sigmah-custom-handicapinternational</id>
 
-                        <build>
-                                <finalName>sigmah-hi_v${project.version}</finalName>
-                                <plugins>
-                                        <plugin>
-                                                <groupId>com.google.code.maven-replacer-plugin</groupId>
-                                                <artifactId>replacer</artifactId>
-                                                <version>1.5.3</version>
-                                                <executions>
-                                                        <execution>
-                                                                <phase>process-sources</phase>
-                                                                <goals>
-                                                                        <goal>replace</goal>
-                                                                </goals>
-                                                        </execution>
-                                                </executions>
+			<build>
+				<finalName>sigmah-hi_v${project.version}</finalName>
+				<plugins>
+					<plugin>
+						<groupId>com.google.code.maven-replacer-plugin</groupId>
+						<artifactId>replacer</artifactId>
+						<version>1.5.3</version>
+						<executions>
+							<execution>
+								<phase>process-sources</phase>
+								<goals>
+									<goal>replace</goal>
+								</goals>
+							</execution>
+						</executions>
 
-                                                <configuration>
-                                                        <basedir>${basedir}</basedir>
-                                                        <filesToInclude>
-                                                                src/main/resources/org/sigmah/client/i18n/UIConstants.properties,
-                                                                src/main/resources/org/sigmah/client/i18n/UIConstants_en_GB.properties
-                                                        </filesToInclude>
-                                                        <replacements>
-                                                                <replacement>
-                                                                        <token>createProjectTypeNGO=In-house project
-                                                                        </token>
-                                                                        <value>createProjectTypeNGO=Implemented
-                                                                                project
-                                                                        </value>
-                                                                </replacement>
-                                                        </replacements>
-                                                </configuration>
-                                        </plugin>
+						<configuration>
+							<basedir>${basedir}</basedir>
+							<filesToInclude>
+								src/main/resources/org/sigmah/client/i18n/UIConstants.properties,
+								src/main/resources/org/sigmah/client/i18n/UIConstants_en_GB.properties
+							</filesToInclude>
+							<replacements>
+								<replacement>
+									<token>createProjectTypeNGO=In-house project
+									</token>
+									<value>createProjectTypeNGO=Implemented
+										project
+									</value>
+								</replacement>
+							</replacements>
+						</configuration>
+					</plugin>
 
 
-                                        <plugin>
-                                                <groupId>org.sigmah</groupId>
-                                                <artifactId>sigmah-maven-plugin</artifactId>
-                                                <version>${maven-sigmah-plugin.version}</version>
-                                                <executions>
-                                                        <execution>
-                                                                <phase>process-sources</phase>
-                                                                <goals>
-                                                                        <goal>sigmah</goal>
-                                                                </goals>
-                                                        </execution>
-                                                </executions>
-                                                <configuration>
-                                                        <version>
-                                                                <!-- Maven property: ${sigmah.version.number} -->
-                                                                <number>${project.version}-hi</number>
-                                                                <!-- Maven property: ${sigmah.version.name} -->
-                                                                <name>Handicap International custom version</name>
-                                                                <!-- Maven property: ${sigmah.version.date} -->
-                                                        </version>
-                                                </configuration>
-                                        </plugin>
+					<plugin>
+						<groupId>org.sigmah</groupId>
+						<artifactId>sigmah-maven-plugin</artifactId>
+						<version>${maven-sigmah-plugin.version}</version>
+						<executions>
+							<execution>
+								<phase>process-sources</phase>
+								<goals>
+									<goal>sigmah</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<version>
+								<!-- Maven property: ${sigmah.version.number} -->
+								<number>${project.version}-hi</number>
+								<!-- Maven property: ${sigmah.version.name} -->
+								<name>Handicap International custom version</name>
+								<!-- Maven property: ${sigmah.version.date} -->
+							</version>
+						</configuration>
+					</plugin>
 
-                                </plugins>
+				</plugins>
 
-                        </build>
+			</build>
 
-                </profile>
+		</profile>
 
 		<profile>
 			<id>sigmah-check-bundles-integrity</id>
@@ -1194,7 +1221,8 @@
 				</property>
 			</activation>
 			<properties>
-				<!-- au release:perform, on ne souhaite pas déployer vers un dépôt d'artifact maven, on ne produit pas la javadoc car trop d'erreur de validation -->
+				<!-- au release:perform, on ne souhaite pas déployer vers un dépôt d'artifact 
+					maven, on ne produit pas la javadoc car trop d'erreur de validation -->
 				<maven.deploy.skip>true</maven.deploy.skip>
 				<maven.javadoc.skip>true</maven.javadoc.skip>
 			</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -932,8 +932,7 @@
 					<runTarget>/</runTarget>
 					<localWorkers>4</localWorkers>
 					<module>org.sigmah.Sigmah</module>
-					<extraJvmArgs>-Xmx1G -Xss512M -XX:PermSize=256M
-						-Djava.io.tmpdir=${project.build.directory}</extraJvmArgs>
+					<extraJvmArgs>-Xmx1G -Xss256M</extraJvmArgs>
 				</configuration>
 			</plugin>
 

--- a/src/main/java/org/sigmah/client/ClientFactory.java
+++ b/src/main/java/org/sigmah/client/ClientFactory.java
@@ -1,0 +1,791 @@
+package org.sigmah.client;
+
+import org.sigmah.client.cache.UserLocalCache;
+import org.sigmah.client.computation.ClientValueResolver;
+import org.sigmah.client.computation.ComputationTriggerManager;
+import org.sigmah.client.dispatch.DispatchAsync;
+import org.sigmah.client.dispatch.ExceptionHandler;
+import org.sigmah.client.event.EventBus;
+import org.sigmah.client.page.PageManager;
+import org.sigmah.client.security.AuthenticationProvider;
+import org.sigmah.client.ui.presenter.ApplicationPresenter;
+import org.sigmah.client.ui.presenter.CreateProjectPresenter;
+import org.sigmah.client.ui.presenter.CreditsPresenter;
+import org.sigmah.client.ui.presenter.DashboardPresenter;
+import org.sigmah.client.ui.presenter.HelpPresenter;
+import org.sigmah.client.ui.presenter.LoginPresenter;
+import org.sigmah.client.ui.presenter.MockUpPresenter;
+import org.sigmah.client.ui.presenter.admin.AdminPresenter;
+import org.sigmah.client.ui.presenter.admin.CategoriesAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.ParametersAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.ReportModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.importation.AddImportationSchemePresenter;
+import org.sigmah.client.ui.presenter.admin.importation.AddVariableImporationSchemePresenter;
+import org.sigmah.client.ui.presenter.admin.importation.ImportationSchemeAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.AddBudgetSubFieldPresenter;
+import org.sigmah.client.ui.presenter.admin.models.EditFlexibleElementAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.EditLayoutGroupAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.FlexibleElementsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.contact.AddContactModelAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.contact.ContactModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.importer.AddImportationSchemeModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.importer.AddMatchingRuleImportationShemeModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.importer.ImportModelPresenter;
+import org.sigmah.client.ui.presenter.admin.models.importer.ImportationSchemeModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.orgunit.AddOrgUnitModelAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.orgunit.OrgUnitModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.project.AddProjectModelAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.project.EditPhaseModelAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.project.LogFrameModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.project.PhaseModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.project.ProjectModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.orgunits.AddOrgUnitAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.orgunits.MoveOrgUnitAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.orgunits.OrgUnitsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.users.PrivacyGroupEditPresenter;
+import org.sigmah.client.ui.presenter.admin.users.ProfileEditPresenter;
+import org.sigmah.client.ui.presenter.admin.users.UserEditPresenter;
+import org.sigmah.client.ui.presenter.admin.users.UsersAdminPresenter;
+import org.sigmah.client.ui.presenter.calendar.CalendarEventPresenter;
+import org.sigmah.client.ui.presenter.calendar.CalendarPresenter;
+import org.sigmah.client.ui.presenter.contact.ContactDetailsPresenter;
+import org.sigmah.client.ui.presenter.contact.ContactHistoryPresenter;
+import org.sigmah.client.ui.presenter.contact.ContactPresenter;
+import org.sigmah.client.ui.presenter.contact.ContactRelationshipsPresenter;
+import org.sigmah.client.ui.presenter.contact.dashboardlist.ContactsListWidget;
+import org.sigmah.client.ui.presenter.contact.export.ExportContactsPresenter;
+import org.sigmah.client.ui.presenter.contact.export.ExportContactsSettingPresenter;
+import org.sigmah.client.ui.presenter.importation.ImportationPresenter;
+import org.sigmah.client.ui.presenter.orgunit.OrgUnitCalendarPresenter;
+import org.sigmah.client.ui.presenter.orgunit.OrgUnitDashboardPresenter;
+import org.sigmah.client.ui.presenter.orgunit.OrgUnitDetailsPresenter;
+import org.sigmah.client.ui.presenter.orgunit.OrgUnitPresenter;
+import org.sigmah.client.ui.presenter.orgunit.OrgUnitReportsPresenter;
+import org.sigmah.client.ui.presenter.password.ChangeOwnPasswordPresenter;
+import org.sigmah.client.ui.presenter.password.LostPasswordPresenter;
+import org.sigmah.client.ui.presenter.password.ResetPasswordPresenter;
+import org.sigmah.client.ui.presenter.project.LinkedProjectPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectCalendarPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectDetailsPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectReportsPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectTeamMembersPresenter;
+import org.sigmah.client.ui.presenter.project.dashboard.PhasesPresenter;
+import org.sigmah.client.ui.presenter.project.dashboard.ProjectDashboardPresenter;
+import org.sigmah.client.ui.presenter.project.export.ExportProjectsPresenter;
+import org.sigmah.client.ui.presenter.project.export.ExportProjectsSettingPresenter;
+import org.sigmah.client.ui.presenter.project.indicator.EditIndicatorPresenter;
+import org.sigmah.client.ui.presenter.project.indicator.EditSitePresenter;
+import org.sigmah.client.ui.presenter.project.indicator.ProjectIndicatorEntriesPresenter;
+import org.sigmah.client.ui.presenter.project.indicator.ProjectIndicatorManagementPresenter;
+import org.sigmah.client.ui.presenter.project.indicator.ProjectIndicatorMapPresenter;
+import org.sigmah.client.ui.presenter.project.logframe.ProjectLogFramePresenter;
+import org.sigmah.client.ui.presenter.project.projectcore.ProjectCoreDiffPresenter;
+import org.sigmah.client.ui.presenter.project.projectcore.ProjectCoreRenameVersionPresenter;
+import org.sigmah.client.ui.presenter.project.treegrid.ProjectsListWidget;
+import org.sigmah.client.ui.presenter.reminder.ReminderEditPresenter;
+import org.sigmah.client.ui.presenter.reminder.ReminderHistoryPresenter;
+import org.sigmah.client.ui.presenter.reports.AttachFilePresenter;
+import org.sigmah.client.ui.presenter.reports.ReportCreatePresenter;
+import org.sigmah.client.ui.presenter.reports.ReportsPresenter;
+import org.sigmah.client.ui.presenter.zone.AppLoaderPresenter;
+import org.sigmah.client.ui.presenter.zone.AuthenticationBannerPresenter;
+import org.sigmah.client.ui.presenter.zone.MenuBannerPresenter;
+import org.sigmah.client.ui.presenter.zone.MessageBannerPresenter;
+import org.sigmah.client.ui.presenter.zone.OfflineBannerPresenter;
+import org.sigmah.client.ui.presenter.zone.OrganizationBannerPresenter;
+import org.sigmah.client.ui.theme.Theme;
+import org.sigmah.client.ui.view.*;
+import org.sigmah.client.ui.view.admin.AdminView;
+import org.sigmah.client.ui.view.admin.CategoriesAdminView;
+import org.sigmah.client.ui.view.admin.ParametersAdminView;
+import org.sigmah.client.ui.view.admin.ReportModelsAdminView;
+import org.sigmah.client.ui.view.admin.importation.AddImportationSchemeView;
+import org.sigmah.client.ui.view.admin.importation.AddVariableImporationSchemeView;
+import org.sigmah.client.ui.view.admin.importation.ImportationSchemeAdminView;
+import org.sigmah.client.ui.view.admin.models.AddBudgetSubFieldView;
+import org.sigmah.client.ui.view.admin.models.EditFlexibleElementAdminView;
+import org.sigmah.client.ui.view.admin.models.EditLayoutGroupAdminView;
+import org.sigmah.client.ui.view.admin.models.FlexibleElementsAdminView;
+import org.sigmah.client.ui.view.admin.models.contact.AddContactModelAdminView;
+import org.sigmah.client.ui.view.admin.models.contact.ContactModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.importer.AddImportationSchemeModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.importer.AddMatchingRuleImportationShemeModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.importer.ImportModelView;
+import org.sigmah.client.ui.view.admin.models.importer.ImportationSchemeModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.orgunit.AddOrgUnitModelAdminView;
+import org.sigmah.client.ui.view.admin.models.orgunit.OrgUnitModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.project.AddProjectModelAdminView;
+import org.sigmah.client.ui.view.admin.models.project.EditPhaseModelAdminView;
+import org.sigmah.client.ui.view.admin.models.project.LogFrameModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.project.PhaseModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.project.ProjectModelsAdminView;
+import org.sigmah.client.ui.view.admin.orgunits.AddOrgUnitAdminView;
+import org.sigmah.client.ui.view.admin.orgunits.MoveOrgUnitAdminView;
+import org.sigmah.client.ui.view.admin.orgunits.OrgUnitsAdminView;
+import org.sigmah.client.ui.view.admin.users.PrivacyGroupEditView;
+import org.sigmah.client.ui.view.admin.users.ProfileEditView;
+import org.sigmah.client.ui.view.admin.users.UserEditView;
+import org.sigmah.client.ui.view.admin.users.UsersAdminView;
+import org.sigmah.client.ui.view.calendar.CalendarEventView;
+import org.sigmah.client.ui.view.calendar.CalendarView;
+import org.sigmah.client.ui.view.contact.ContactDetailsView;
+import org.sigmah.client.ui.view.contact.ContactHistoryView;
+import org.sigmah.client.ui.view.contact.ContactRelationshipsView;
+import org.sigmah.client.ui.view.contact.ContactView;
+import org.sigmah.client.ui.view.contact.dashboardlist.ContactsListView;
+import org.sigmah.client.ui.view.contact.export.ExportContactsSettingView;
+import org.sigmah.client.ui.view.contact.export.ExportContactsView;
+import org.sigmah.client.ui.view.importation.ImportationView;
+import org.sigmah.client.ui.view.orgunit.OrgUnitCalendarView;
+import org.sigmah.client.ui.view.orgunit.OrgUnitDashboardView;
+import org.sigmah.client.ui.view.orgunit.OrgUnitDetailsView;
+import org.sigmah.client.ui.view.orgunit.OrgUnitReportsView;
+import org.sigmah.client.ui.view.orgunit.OrgUnitView;
+import org.sigmah.client.ui.view.password.*;
+import org.sigmah.client.ui.view.pivot.ProjectPivotContainer;
+import org.sigmah.client.ui.view.pivot.table.PivotGridPanel;
+import org.sigmah.client.ui.view.project.LinkedProjectView;
+import org.sigmah.client.ui.view.project.ProjectCalendarView;
+import org.sigmah.client.ui.view.project.ProjectDetailsView;
+import org.sigmah.client.ui.view.project.ProjectReportsView;
+import org.sigmah.client.ui.view.project.ProjectTeamMembersView;
+import org.sigmah.client.ui.view.project.ProjectView;
+import org.sigmah.client.ui.view.project.dashboard.PhasesView;
+import org.sigmah.client.ui.view.project.dashboard.ProjectDashboardView;
+import org.sigmah.client.ui.view.project.export.ExportProjectsSettingView;
+import org.sigmah.client.ui.view.project.export.ExportProjectsView;
+import org.sigmah.client.ui.view.project.indicator.EditIndicatorView;
+import org.sigmah.client.ui.view.project.indicator.EditSiteView;
+import org.sigmah.client.ui.view.project.indicator.ProjectIndicatorEntriesView;
+import org.sigmah.client.ui.view.project.indicator.ProjectIndicatorManagementView;
+import org.sigmah.client.ui.view.project.indicator.ProjectIndicatorMapView;
+import org.sigmah.client.ui.view.project.indicator.SiteGridPanel;
+import org.sigmah.client.ui.view.project.logframe.ProjectLogFrameGrid;
+import org.sigmah.client.ui.view.project.logframe.ProjectLogFrameView;
+import org.sigmah.client.ui.view.project.projectcore.ProjectCoreDiffView;
+import org.sigmah.client.ui.view.project.projectcore.ProjectCoreRenameVersionView;
+import org.sigmah.client.ui.view.project.treegrid.ProjectsListView;
+import org.sigmah.client.ui.view.reminder.ReminderEditView;
+import org.sigmah.client.ui.view.reminder.ReminderHistoryView;
+import org.sigmah.client.ui.view.reports.*;
+import org.sigmah.client.ui.view.zone.*;
+import org.sigmah.client.util.ImageProvider;
+import org.sigmah.offline.dao.*;
+import org.sigmah.offline.dispatch.LocalDispatchServiceAsync;
+import org.sigmah.offline.handler.ActivityCalendarAsyncHandler;
+import org.sigmah.offline.handler.BatchCommandAsyncHandler;
+import org.sigmah.offline.handler.CreateEntityAsyncHandler;
+import org.sigmah.offline.handler.DeleteAsyncHandler;
+import org.sigmah.offline.handler.GetCalendarAsyncHandler;
+import org.sigmah.offline.handler.GetCategoriesAsyncHandler;
+import org.sigmah.offline.handler.GetCountriesAsyncHandler;
+import org.sigmah.offline.handler.GetCountryAsyncHandler;
+import org.sigmah.offline.handler.GetHistoryAsyncHandler;
+import org.sigmah.offline.handler.GetLinkedProjectsAsyncHandler;
+import org.sigmah.offline.handler.GetMonitoredPointsAsyncHandler;
+import org.sigmah.offline.handler.GetOrgUnitAsyncHandler;
+import org.sigmah.offline.handler.GetOrgUnitsAsyncHandler;
+import org.sigmah.offline.handler.GetOrganizationAsyncHandler;
+import org.sigmah.offline.handler.GetProfilesAsyncHandler;
+import org.sigmah.offline.handler.GetProjectAsyncHandler;
+import org.sigmah.offline.handler.GetProjectDocumentsAsyncHandler;
+import org.sigmah.offline.handler.GetProjectReportAsyncHandler;
+import org.sigmah.offline.handler.GetProjectReportsAsyncHandler;
+import org.sigmah.offline.handler.GetProjectTeamMembersAsyncHandler;
+import org.sigmah.offline.handler.GetProjectsAsyncHandler;
+import org.sigmah.offline.handler.GetProjectsFromIdAsyncHandler;
+import org.sigmah.offline.handler.GetRemindersAsyncHandler;
+import org.sigmah.offline.handler.GetSitesCountAsyncHandler;
+import org.sigmah.offline.handler.GetUserUnitsByUserAsyncHandler;
+import org.sigmah.offline.handler.GetUsersByOrgUnitAsyncHandler;
+import org.sigmah.offline.handler.GetUsersByOrganizationAsyncHandler;
+import org.sigmah.offline.handler.GetValueAsyncHandler;
+import org.sigmah.offline.handler.GetValueFromLinkedProjectsAsyncHandler;
+import org.sigmah.offline.handler.MonitoredPointCalendarAsyncHandler;
+import org.sigmah.offline.handler.PersonalCalendarAsyncHandler;
+import org.sigmah.offline.handler.PrepareFileUploadAsyncHandler;
+import org.sigmah.offline.handler.ReminderCalendarAsyncHandler;
+import org.sigmah.offline.handler.SecureNavigationAsyncHandler;
+import org.sigmah.offline.handler.UpdateEntityAsyncHandler;
+import org.sigmah.offline.handler.UpdateLogFrameAsyncHandler;
+import org.sigmah.offline.handler.UpdateMonitoredPointsAsyncHandler;
+import org.sigmah.offline.handler.UpdateProjectAsyncHandler;
+import org.sigmah.offline.handler.UpdateProjectFavoriteAsyncHandler;
+import org.sigmah.offline.handler.UpdateProjectTeamMembersAsyncHandler;
+import org.sigmah.offline.handler.UpdateRemindersAsyncHandler;
+import org.sigmah.offline.presenter.FileSelectionPresenter;
+import org.sigmah.offline.status.ApplicationStateManager;
+import org.sigmah.offline.sync.Synchronizer;
+import org.sigmah.offline.view.FileSelectionView;
+import org.sigmah.shared.dto.ContactModelDTO;
+import org.sigmah.shared.dto.IsModel;
+import org.sigmah.shared.dto.OrgUnitModelDTO;
+import org.sigmah.shared.dto.ProjectModelDTO;
+import org.sigmah.shared.dto.pivot.content.IStateManager;
+import org.sigmah.shared.file.TransfertManager;
+import org.sigmah.shared.file.TransfertManagerProvider;
+
+public interface ClientFactory {
+	
+	
+	EventBus getEventBus();
+
+	DispatchAsync getDispatch();
+
+	LocalDispatchServiceAsync getLocalDispatch();
+
+	PageManager getPageManager();
+
+	Theme getTheme();
+
+	AuthenticationProvider getAuthenticationProvider();
+
+	ApplicationStateManager getApplicationStateManager();
+	
+	IStateManager getIStateManager();
+
+	TransfertManager getTransfertManager();
+
+	Synchronizer getSynchronizer();
+
+	UserLocalCache getClientCache();
+
+	// --------------------------------------------------
+	//
+	// Asynchronous DAO (offline mode).
+	//
+	// --------------------------------------------------
+
+	FileDataAsyncDAO getFileDataAsyncDAO();
+
+	TransfertAsyncDAO getTransfertAsyncDAO();
+
+	// --------------------------------------------------
+	//
+	// Presenters.
+	//
+	// --------------------------------------------------
+
+	ApplicationPresenter getApplicationPresenter();
+
+	// ---- Zones presenters.
+
+	MockUpPresenter getMockUpPresenter();
+
+	OrganizationBannerPresenter getOrganizationBannerPresenter();
+
+	AuthenticationBannerPresenter getAuthenticationBannerPresenter();
+
+	OfflineBannerPresenter getOfflineBannerPresenter();
+
+	AppLoaderPresenter getAppLoaderPresenter();
+
+	MenuBannerPresenter getMenuBannerPresenter();
+
+	MessageBannerPresenter getMessageBannerPresenter();
+
+	CreditsPresenter getCreditsPresenter();
+
+	HelpPresenter getHelpPresenter();
+
+	// ---- Pages presenters.
+
+	DashboardPresenter getHomePresenter();
+
+	LoginPresenter getLoginPresenter();
+
+	LostPasswordPresenter getLostPasswordPresenter();
+
+	ResetPasswordPresenter getResetPasswordPresenter();
+
+	ChangeOwnPasswordPresenter getChangeOwnPasswordPresenter();
+
+	CreateProjectPresenter getCreateProjectPresenter();
+
+	CalendarEventPresenter getCalendarEventPresenter();
+
+	ReportCreatePresenter getReportCreatePresenter();
+
+	AttachFilePresenter getAttachFilePresenter();
+
+	ImportationPresenter getImportationPresenter();
+
+	// ---- Project presenters.
+
+	ProjectPresenter getProjectPresenter();
+
+	ProjectDashboardPresenter getProjectDashboardPresenter();
+
+	ProjectLogFramePresenter getProjectLogFramePresenter();
+
+	ProjectDetailsPresenter getProjectDetailsPresenter();
+
+	ProjectTeamMembersPresenter getProjectTeamMembersPresenter();
+
+	ProjectCalendarPresenter getProjectCalendarPresenter();
+
+	ProjectReportsPresenter getProjectReportsPresenter();
+
+	ReminderEditPresenter getReminderEditPresenter();
+
+	ReminderHistoryPresenter getReminderHistoryPresenter();
+
+	LinkedProjectPresenter getLinkedProjectPresenter();
+
+	ProjectIndicatorEntriesPresenter getProjectIndicatorEntriesPresenter();
+
+	ProjectIndicatorManagementPresenter getProjectIndicatorManagementPresenter();
+
+	ProjectIndicatorMapPresenter getProjectIndicatorMapPresenter();
+
+	EditIndicatorPresenter getEditIndicatorPresenter();
+
+	EditSitePresenter getEditSitePresenter();
+
+	ExportContactsPresenter getExportContactsPresenter();
+
+	ExportContactsSettingPresenter getExportContactsSettingPresenter();
+
+	ExportProjectsPresenter getExportProjectsPresenter();
+
+	ExportProjectsSettingPresenter getExportProjectsSettingPresenter();
+
+	ProjectCoreRenameVersionPresenter getProjectCoreRenameVersionPresenter();
+
+	ProjectCoreDiffPresenter getProjectCoreDiffPresenter();
+
+	// ---- OrgUnit presenters.
+
+	OrgUnitPresenter getOrgUnitPresenter();
+
+	OrgUnitDashboardPresenter getOrgUnitDashboardPresenter();
+
+	OrgUnitDetailsPresenter getOrgUnitDetailsPresenter();
+
+	OrgUnitCalendarPresenter getOrgUnitCalendarPresenter();
+
+	OrgUnitReportsPresenter getOrgUnitReportsPresenter();
+
+	// ---- Contact presenters
+
+	ContactPresenter getContactPresenter();
+
+	ContactDetailsPresenter getContactDetailsPresenter();
+
+	ContactRelationshipsPresenter getContactRelationshipsPresenter();
+
+	ContactHistoryPresenter getContactHistoryPresenter();
+
+	// ---- Admin presenters
+
+	AdminPresenter getAdminPresenter();
+
+	ParametersAdminPresenter getParametersAdminPresenter();
+
+	UsersAdminPresenter getUsersAdminPresenter();
+
+	PrivacyGroupEditPresenter getPrivacyGroupEditPresenter();
+
+	ProfileEditPresenter getProfileEditPresenter();
+
+	UserEditPresenter getUserEditPresenter();
+
+	OrgUnitsAdminPresenter getOrgUnitsAdminPresenter();
+
+	AddOrgUnitAdminPresenter getAddOrgUnitAdminPresenter();
+
+	MoveOrgUnitAdminPresenter getMoveOrgUnitAdminPresenter();
+
+	CategoriesAdminPresenter getCategoriesAdminPresenter();
+
+	OrgUnitModelsAdminPresenter getOrgUnitModelsAdminPresenter();
+
+	AddOrgUnitModelAdminPresenter getAddOrgUnitModelAdminPresenter();
+
+	ProjectModelsAdminPresenter getProjectModelsAdminPresenter();
+
+	AddProjectModelAdminPresenter getAddProjectModelAdminPresenter();
+
+	ContactModelsAdminPresenter getContactModelsAdminPresenter();
+
+	AddContactModelAdminPresenter getAddContactModelAdminPresenter();
+
+	AddImportationSchemePresenter getAddImportationSchemePresenter();
+
+	ReportModelsAdminPresenter getReportModelsAdminPresenter();
+
+	EditPhaseModelAdminPresenter getEditPhaseModelAdminPresenter();
+
+	EditLayoutGroupAdminPresenter getEditLayoutGroupAdminPresenter();
+
+	EditFlexibleElementAdminPresenter getEditFlexibleElementAdminPresenter();
+
+	AddBudgetSubFieldPresenter getAddBudgetSubFieldPresenter();
+
+	ImportModelPresenter getImportModelPresenter();
+
+	ImportationSchemeAdminPresenter getImportationShemePresenter();
+
+	AddVariableImporationSchemePresenter getAddVariableImporationSchemePresenter();
+
+	AddImportationSchemeModelsAdminPresenter getAddImportationSchemeModelsAdminPresenter();
+
+	AddMatchingRuleImportationShemeModelsAdminPresenter getAddMatchingRuleImportationShemeModelsAdminPresenter();
+
+	// ---- Offline presenters
+
+	FileSelectionPresenter getFileSelectionPresenter();
+	
+	UpdateDiaryAsyncDAO getUpdateDiaryAsyncDAO();
+	
+	TransfertManagerProvider getTransferManagerProvider();
+	
+	MonitoredPointAsyncDAO getMonitoredPointAsyncDAO();
+	
+	OrgUnitAsyncDAO getOrgUnitAsyncDAO();
+	
+	ReminderAsyncDAO getReminderAsyncDAO();
+	
+	ApplicationView getApplicationView();
+	
+	MockUpView getMockUpView();
+	
+	OrganizationBannerView getOrganizationBannerView();
+	
+	AuthenticationBannerView getAuthenticationBannerView();
+	
+	ImageProvider getImageProvider();
+	
+	LogoAsyncDAO getLogoAsyncDAO();
+	
+	OfflineBannerView getOfflineBannerView();
+	
+	AppLoaderView getAppLoaderView();
+	
+	MenuBannerView getMenuBannerView();
+	
+	MessageBannerView getMessageBannerView();
+	
+    CreditsView getCreditsView();
+    
+    HelpView getHelpView();
+    
+    ContactsListWidget getContactsListWidget();
+    
+    ProjectsListWidget getProjectsListWidget();
+    
+    ContactsListView getContactsListView();
+    
+    ProjectsListView getProjectsListView();
+    
+    DashboardView getDashboardView();
+    
+    LoginView getLoginView();
+    
+    LostPasswordView getLostPasswordView();
+    
+    ResetPasswordView getResetPasswordView();
+    
+    ChangeOwnPasswordView getChangeOwnPasswordView();
+    
+    CreateProjectView getCreateProjectView();
+    
+    CalendarEventView getCalendarEventView();
+    
+    ReportCreateView getReportCreateView();
+    
+    AttachFileView getAttachFileView();
+    
+    ImportationView getImportationView();
+    
+    ProjectView getProjectView();
+    
+    ProjectDashboardView getProjectDashboardView();
+
+    ProjectLogFrameView getProjectLogFrameView();
+
+    ProjectDetailsView getProjectDetailsView();
+
+    ProjectTeamMembersView getProjectTeamMembersView();
+
+    ProjectCalendarView getProjectCalendarView();
+
+    ProjectReportsView getProjectReportsView();
+
+    ReminderEditView getReminderEditView();
+
+    ReminderHistoryView getReminderHistoryView();
+
+    LinkedProjectView getLinkedProjectView();
+
+    ProjectIndicatorEntriesView getProjectIndicatorEntriesView();
+
+    ProjectIndicatorManagementView getProjectIndicatorManagementView();
+
+    ProjectIndicatorMapView getProjectIndicatorMapView();
+
+    EditIndicatorView getEditIndicatorView();
+
+    EditSiteView getEditSiteView();
+
+    ExportContactsView getExportContactsView();
+
+    ExportContactsSettingView getExportContactsSettingView();
+
+    ExportProjectsView getExportProjectsView();
+
+    ExportProjectsSettingView getExportProjectsSettingView();
+
+    ProjectCoreRenameVersionView getProjectCoreRenameVersionView();
+
+    ProjectCoreDiffView getProjectCoreDiffView();
+
+    OrgUnitView getOrgUnitView();
+
+    OrgUnitDashboardView getOrgUnitDashboardView();
+
+    OrgUnitDetailsView getOrgUnitDetailsView();
+
+    OrgUnitCalendarView getOrgUnitCalendarView();
+
+    OrgUnitReportsView getOrgUnitReportsView();
+
+    ContactView getContactView();
+
+    ContactDetailsView getContactDetailsView();
+
+    ContactRelationshipsView getContactRelationshipsView();
+
+    ContactHistoryView getContactHistoryView();
+
+    AdminView getAdminView();
+
+    ParametersAdminView getParametersAdminView();
+
+    UsersAdminView getUsersAdminView();
+
+    PrivacyGroupEditView getPrivacyGroupEditView();
+
+    ProfileEditView getProfileEditView();
+
+    UserEditView getUserEditView();
+
+    OrgUnitsAdminView getOrgUnitsAdminView();
+
+    AddOrgUnitAdminView getAddOrgUnitAdminView();
+
+    MoveOrgUnitAdminView getMoveOrgUnitAdminView();
+
+    CategoriesAdminView getCategoriesAdminView();
+
+    OrgUnitModelsAdminView getOrgUnitModelsAdminView();
+
+    AddOrgUnitModelAdminView getAddOrgUnitModelAdminView();
+
+    ProjectModelsAdminView getProjectModelsAdminView();
+
+    AddProjectModelAdminView getAddProjectModelAdminView();
+
+    ContactModelsAdminView getContactModelsAdminView();
+
+    AddContactModelAdminView getAddContactModelAdminView();
+
+    AddImportationSchemeView getAddImportationSchemeView();
+
+    ReportModelsAdminView getReportModelsAdminView();
+
+    EditPhaseModelAdminView getEditPhaseModelAdminView();
+
+    EditLayoutGroupAdminView getEditLayoutGroupAdminView();
+
+    EditFlexibleElementAdminView getEditFlexibleElementAdminView();
+
+    AddBudgetSubFieldView getAddBudSubFieldView();
+
+    ImportModelView getImportModelView();
+
+    ImportationSchemeAdminView getImportationSchemeAdminView();
+
+    AddVariableImporationSchemeView getAddVariableImporationSchemeView();
+
+    AddImportationSchemeModelsAdminView getAddImportationSchemeModelsAdminView();
+
+    AddMatchingRuleImportationShemeModelsAdminView getAddMatchingRuleImportationShemeModelsAdminView();
+
+    FileSelectionView getFileSelectionView();
+    
+    PhasesPresenter getPhasesPresenter();
+    
+    PhasesView getPhasesView();
+    
+    ProjectLogFrameGrid getProjectLogFrameGrid();
+    
+    ProjectPivotContainer getProjectPivotContainer();
+    
+    PivotGridPanel getPivotGridPanel();
+    
+    SiteGridPanel getSiteGridPanel();
+    
+    ComputationTriggerManager getComputationTriggerManager();
+    
+    ClientValueResolver getClientValueResolver();
+    
+    ReportsPresenter getReportsPresenter();
+    
+    ReportsView getReportsView();
+    
+    CalendarPresenter getCalendarPresenter();
+    
+    CalendarView getCalendarView();
+    
+    FlexibleElementsAdminPresenter<OrgUnitModelDTO> getFlexibleElementsAdminPresenter();
+    
+    FlexibleElementsAdminPresenter<ProjectModelDTO> getFlexibleElementsAdminPresenter2(); 
+    
+    FlexibleElementsAdminPresenter<ContactModelDTO> getFlexibleElementsAdminPresenter3(); 
+    
+    FlexibleElementsAdminView getFlexibleElementsAdminView();
+    
+    ImportationSchemeModelsAdminView getImportationSchemeModelsAdminView();
+    
+    ImportationSchemeModelsAdminPresenter<OrgUnitModelDTO> getImportationSchemeModelsAdminPresenter();
+    
+    ImportationSchemeModelsAdminPresenter<ProjectModelDTO> getImportationSchemeModelsAdminPresenter2();
+    
+    PhaseModelsAdminPresenter getPhaseModelsAdminPresenter();
+    
+    PhaseModelsAdminView getPhaseModelsAdminView();
+    
+    LogFrameModelsAdminPresenter getLogFrameModelsAdminPresenter();
+    
+    LogFrameModelsAdminView getLogFrameModelsAdminView();
+    
+    ProjectAsyncDAO getProjectAsyncDAO();
+    
+    ProjectModelAsyncDAO getProjectModelAsyncDAO();
+    
+    PhaseAsyncDAO getPhaseAsyncDAO();
+    
+    LogFrameAsyncDAO getLogFrameAsyncDAO();
+    
+    ValueAsyncDAO getValueAsyncDAO();
+    
+    OrgUnitModelAsyncDAO getOrgUnitModelAsyncDAO();
+    
+    CountryAsyncDAO getCountryAsyncDAO();
+    
+    PhaseModelAsyncDAO getPhaseModelAsyncDAO();
+    
+    ComputationAsyncDAO getComputationAsyncDAO();
+    
+    BatchCommandAsyncHandler getBatchCommandAsyncHandler();
+
+    CreateEntityAsyncHandler getCreateEntityAsyncHandler();
+
+    DeleteAsyncHandler getDeleteAsyncHandler();
+
+    GetCalendarAsyncHandler getGetCalendarAsyncHandler();
+
+    GetCategoriesAsyncHandler getGetCategoriesAsyncHandler();
+
+    GetCountriesAsyncHandler getGetCountriesAsyncHandler();
+
+    GetCountryAsyncHandler getGetCountryAsyncHandler();
+
+    GetHistoryAsyncHandler getGetHistoryAsyncHandler();
+
+    GetLinkedProjectsAsyncHandler getGetLinkedProjectsAsyncHandler();
+
+    GetMonitoredPointsAsyncHandler getGetMonitoredPointsAsyncHandler();
+
+    GetOrganizationAsyncHandler getGetOrganizationAsyncHandler();
+
+    GetOrgUnitAsyncHandler getGetOrgUnitAsyncHandler();
+
+    GetOrgUnitsAsyncHandler getGetOrgUnitsAsyncHandler();
+
+    GetProfilesAsyncHandler getGetProfilesAsyncHandler();
+
+    GetProjectAsyncHandler getGetProjectAsyncHandler();
+
+    GetProjectsAsyncHandler getGetProjectsAsyncHandler();
+
+    GetProjectsFromIdAsyncHandler getGetProjectsFromIdAsyncHandler();
+
+    GetProjectDocumentsAsyncHandler getGetProjectDocumentsAsyncHandler();
+
+    GetProjectReportAsyncHandler getGetProjectReportAsyncHandler();
+
+    GetProjectReportsAsyncHandler getGetProjectReportsAsyncHandler();
+
+    GetProjectTeamMembersAsyncHandler getGetProjectTeamMembersAsyncHandler();
+
+    GetRemindersAsyncHandler getGetRemindersAsyncHandler();
+
+    GetSitesCountAsyncHandler getGetSitesCountAsyncHandler();
+
+    GetUsersByOrganizationAsyncHandler getGetUsersByOrganizationAsyncHandler();
+
+    GetUsersByOrgUnitAsyncHandler getGetUsersByOrgUnitAsyncHandler();
+
+    GetUserUnitsByUserAsyncHandler getGetUserUnitsByUserAsyncHandler();
+
+    GetValueAsyncHandler getGetValueAsyncHandler();
+
+    GetValueFromLinkedProjectsAsyncHandler getGetValueFromLinkedProjectsAsyncHandler();
+
+    PrepareFileUploadAsyncHandler getPrepareFileUploadAsyncHandler();
+
+    SecureNavigationAsyncHandler getSecureNavigationAsyncHandler();
+
+    UpdateEntityAsyncHandler getUpdateEntityAsyncHandler();
+
+    UpdateLogFrameAsyncHandler getUpdateLogFrameAsyncHandler();
+    
+    PersonalCalendarAsyncDAO getPersonalCalendarAsyncDAO();
+
+    UpdateMonitoredPointsAsyncHandler getUpdateMonitoredPointsAsyncHandler();
+
+    UpdateProjectAsyncHandler getUpdateProjectAsyncHandler();
+
+    UpdateProjectFavoriteAsyncHandler getUpdateProjectFavoriteAsyncHandler();
+
+    UpdateProjectTeamMembersAsyncHandler getUpdateProjectTeamMembersAsyncHandler();
+
+    UpdateRemindersAsyncHandler getUpdateRemindersAsyncHandler();
+    
+    ActivityCalendarAsyncHandler getActivityCalendarAsyncHandler();
+
+    PersonalCalendarAsyncHandler getPersonalCalendarAsyncHandler();
+
+    MonitoredPointCalendarAsyncHandler getMonitoredPointCalendarAsyncHandler();
+
+    ReminderCalendarAsyncHandler getReminderCalendarAsyncHandler();
+    
+    CategoryTypeAsyncDAO getCategoryTypeAsyncDAO();
+    
+    HistoryAsyncDAO getHistoryAsyncDAO();
+    
+    OrganizationAsyncDAO getOrganizationAsyncDAO();
+    
+    ProfileAsyncDAO getProfileAsyncDAO();
+    
+    UserAsyncDAO getUserAsyncDAO();
+    
+    UserUnitAsyncDAO getUserUnitAsyncDAO();
+    
+    AuthenticationAsyncDAO getAuthenticationAsyncDAO();
+
+    PageAccessAsyncDAO getPageAccessAsyncDAO();
+    
+    ProjectReportAsyncDAO getProjectReportAsyncDAO();
+    
+    ProjectTeamMembersAsyncDAO getProjectTeamMembersAsyncDAO();
+    
+    ReportReferenceAsyncDAO getReportReferenceAsyncDAO();
+    
+    CategoryElementAsyncDAO getCategoryElementAsyncDAO();
+    
+    ExceptionHandler getExceptionHandler();
+}

--- a/src/main/java/org/sigmah/client/ClientFactoryImpl.java
+++ b/src/main/java/org/sigmah/client/ClientFactoryImpl.java
@@ -1,0 +1,3250 @@
+package org.sigmah.client;
+
+import org.sigmah.client.cache.UserLocalCache;
+import org.sigmah.client.computation.ClientValueResolver;
+import org.sigmah.client.computation.ComputationTriggerManager;
+import org.sigmah.client.dispatch.DispatchAsync;
+import org.sigmah.client.dispatch.ExceptionHandler;
+import org.sigmah.client.event.EventBus;
+import org.sigmah.client.event.EventBusImpl;
+import org.sigmah.client.page.PageManager;
+import org.sigmah.client.security.AuthenticationProvider;
+import org.sigmah.client.security.SecureDispatchAsync;
+import org.sigmah.client.security.SecureExceptionHandler;
+import org.sigmah.client.ui.presenter.ApplicationPresenter;
+import org.sigmah.client.ui.presenter.CreateProjectPresenter;
+import org.sigmah.client.ui.presenter.CreditsPresenter;
+import org.sigmah.client.ui.presenter.DashboardPresenter;
+import org.sigmah.client.ui.presenter.HelpPresenter;
+import org.sigmah.client.ui.presenter.LoginPresenter;
+import org.sigmah.client.ui.presenter.MockUpPresenter;
+import org.sigmah.client.ui.presenter.admin.AdminPresenter;
+import org.sigmah.client.ui.presenter.admin.CategoriesAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.ParametersAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.ReportModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.importation.AddImportationSchemePresenter;
+import org.sigmah.client.ui.presenter.admin.importation.AddVariableImporationSchemePresenter;
+import org.sigmah.client.ui.presenter.admin.importation.ImportationSchemeAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.AddBudgetSubFieldPresenter;
+import org.sigmah.client.ui.presenter.admin.models.EditFlexibleElementAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.EditLayoutGroupAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.FlexibleElementsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.contact.AddContactModelAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.contact.ContactModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.importer.AddImportationSchemeModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.importer.AddMatchingRuleImportationShemeModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.importer.ImportModelPresenter;
+import org.sigmah.client.ui.presenter.admin.models.importer.ImportationSchemeModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.orgunit.AddOrgUnitModelAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.orgunit.OrgUnitModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.project.AddProjectModelAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.project.EditPhaseModelAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.project.LogFrameModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.project.PhaseModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.models.project.ProjectModelsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.orgunits.AddOrgUnitAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.orgunits.MoveOrgUnitAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.orgunits.OrgUnitsAdminPresenter;
+import org.sigmah.client.ui.presenter.admin.users.PrivacyGroupEditPresenter;
+import org.sigmah.client.ui.presenter.admin.users.ProfileEditPresenter;
+import org.sigmah.client.ui.presenter.admin.users.UserEditPresenter;
+import org.sigmah.client.ui.presenter.admin.users.UsersAdminPresenter;
+import org.sigmah.client.ui.presenter.calendar.CalendarEventPresenter;
+import org.sigmah.client.ui.presenter.calendar.CalendarPresenter;
+import org.sigmah.client.ui.presenter.contact.ContactDetailsPresenter;
+import org.sigmah.client.ui.presenter.contact.ContactHistoryPresenter;
+import org.sigmah.client.ui.presenter.contact.ContactPresenter;
+import org.sigmah.client.ui.presenter.contact.ContactRelationshipsPresenter;
+import org.sigmah.client.ui.presenter.contact.dashboardlist.ContactsListWidget;
+import org.sigmah.client.ui.presenter.contact.export.ExportContactsPresenter;
+import org.sigmah.client.ui.presenter.contact.export.ExportContactsSettingPresenter;
+import org.sigmah.client.ui.presenter.importation.ImportationPresenter;
+import org.sigmah.client.ui.presenter.orgunit.OrgUnitCalendarPresenter;
+import org.sigmah.client.ui.presenter.orgunit.OrgUnitDashboardPresenter;
+import org.sigmah.client.ui.presenter.orgunit.OrgUnitDetailsPresenter;
+import org.sigmah.client.ui.presenter.orgunit.OrgUnitPresenter;
+import org.sigmah.client.ui.presenter.orgunit.OrgUnitReportsPresenter;
+import org.sigmah.client.ui.presenter.password.ChangeOwnPasswordPresenter;
+import org.sigmah.client.ui.presenter.password.LostPasswordPresenter;
+import org.sigmah.client.ui.presenter.password.ResetPasswordPresenter;
+import org.sigmah.client.ui.presenter.project.LinkedProjectPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectCalendarPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectDetailsPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectReportsPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectTeamMembersPresenter;
+import org.sigmah.client.ui.presenter.project.dashboard.PhasesPresenter;
+import org.sigmah.client.ui.presenter.project.dashboard.ProjectDashboardPresenter;
+import org.sigmah.client.ui.presenter.project.export.ExportProjectsPresenter;
+import org.sigmah.client.ui.presenter.project.export.ExportProjectsSettingPresenter;
+import org.sigmah.client.ui.presenter.project.indicator.EditIndicatorPresenter;
+import org.sigmah.client.ui.presenter.project.indicator.EditSitePresenter;
+import org.sigmah.client.ui.presenter.project.indicator.ProjectIndicatorEntriesPresenter;
+import org.sigmah.client.ui.presenter.project.indicator.ProjectIndicatorManagementPresenter;
+import org.sigmah.client.ui.presenter.project.indicator.ProjectIndicatorMapPresenter;
+import org.sigmah.client.ui.presenter.project.logframe.ProjectLogFramePresenter;
+import org.sigmah.client.ui.presenter.project.projectcore.ProjectCoreDiffPresenter;
+import org.sigmah.client.ui.presenter.project.projectcore.ProjectCoreRenameVersionPresenter;
+import org.sigmah.client.ui.presenter.project.treegrid.ProjectsListWidget;
+import org.sigmah.client.ui.presenter.reminder.ReminderEditPresenter;
+import org.sigmah.client.ui.presenter.reminder.ReminderHistoryPresenter;
+import org.sigmah.client.ui.presenter.reports.AttachFilePresenter;
+import org.sigmah.client.ui.presenter.reports.ReportCreatePresenter;
+import org.sigmah.client.ui.presenter.reports.ReportsPresenter;
+import org.sigmah.client.ui.presenter.zone.AppLoaderPresenter;
+import org.sigmah.client.ui.presenter.zone.AuthenticationBannerPresenter;
+import org.sigmah.client.ui.presenter.zone.MenuBannerPresenter;
+import org.sigmah.client.ui.presenter.zone.MessageBannerPresenter;
+import org.sigmah.client.ui.presenter.zone.OfflineBannerPresenter;
+import org.sigmah.client.ui.presenter.zone.OrganizationBannerPresenter;
+import org.sigmah.client.ui.theme.SigmahTheme;
+import org.sigmah.client.ui.theme.Theme;
+import org.sigmah.client.ui.view.ApplicationView;
+import org.sigmah.client.ui.view.CreateProjectView;
+import org.sigmah.client.ui.view.CreditsView;
+import org.sigmah.client.ui.view.DashboardView;
+import org.sigmah.client.ui.view.HelpView;
+import org.sigmah.client.ui.view.LoginView;
+import org.sigmah.client.ui.view.MockUpView;
+import org.sigmah.client.ui.view.admin.AdminView;
+import org.sigmah.client.ui.view.admin.CategoriesAdminView;
+import org.sigmah.client.ui.view.admin.ParametersAdminView;
+import org.sigmah.client.ui.view.admin.ReportModelsAdminView;
+import org.sigmah.client.ui.view.admin.importation.AddImportationSchemeView;
+import org.sigmah.client.ui.view.admin.importation.AddVariableImporationSchemeView;
+import org.sigmah.client.ui.view.admin.importation.ImportationSchemeAdminView;
+import org.sigmah.client.ui.view.admin.models.AddBudgetSubFieldView;
+import org.sigmah.client.ui.view.admin.models.EditFlexibleElementAdminView;
+import org.sigmah.client.ui.view.admin.models.EditLayoutGroupAdminView;
+import org.sigmah.client.ui.view.admin.models.FlexibleElementsAdminView;
+import org.sigmah.client.ui.view.admin.models.contact.AddContactModelAdminView;
+import org.sigmah.client.ui.view.admin.models.contact.ContactModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.importer.AddImportationSchemeModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.importer.AddMatchingRuleImportationShemeModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.importer.ImportModelView;
+import org.sigmah.client.ui.view.admin.models.importer.ImportationSchemeModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.orgunit.AddOrgUnitModelAdminView;
+import org.sigmah.client.ui.view.admin.models.orgunit.OrgUnitModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.project.AddProjectModelAdminView;
+import org.sigmah.client.ui.view.admin.models.project.EditPhaseModelAdminView;
+import org.sigmah.client.ui.view.admin.models.project.LogFrameModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.project.PhaseModelsAdminView;
+import org.sigmah.client.ui.view.admin.models.project.ProjectModelsAdminView;
+import org.sigmah.client.ui.view.admin.orgunits.AddOrgUnitAdminView;
+import org.sigmah.client.ui.view.admin.orgunits.MoveOrgUnitAdminView;
+import org.sigmah.client.ui.view.admin.orgunits.OrgUnitsAdminView;
+import org.sigmah.client.ui.view.admin.users.PrivacyGroupEditView;
+import org.sigmah.client.ui.view.admin.users.ProfileEditView;
+import org.sigmah.client.ui.view.admin.users.UserEditView;
+import org.sigmah.client.ui.view.admin.users.UsersAdminView;
+import org.sigmah.client.ui.view.calendar.CalendarEventView;
+import org.sigmah.client.ui.view.calendar.CalendarView;
+import org.sigmah.client.ui.view.contact.ContactDetailsView;
+import org.sigmah.client.ui.view.contact.ContactHistoryView;
+import org.sigmah.client.ui.view.contact.ContactRelationshipsView;
+import org.sigmah.client.ui.view.contact.ContactView;
+import org.sigmah.client.ui.view.contact.dashboardlist.ContactsListView;
+import org.sigmah.client.ui.view.contact.export.ExportContactsSettingView;
+import org.sigmah.client.ui.view.contact.export.ExportContactsView;
+import org.sigmah.client.ui.view.importation.ImportationView;
+import org.sigmah.client.ui.view.orgunit.OrgUnitCalendarView;
+import org.sigmah.client.ui.view.orgunit.OrgUnitDashboardView;
+import org.sigmah.client.ui.view.orgunit.OrgUnitDetailsView;
+import org.sigmah.client.ui.view.orgunit.OrgUnitReportsView;
+import org.sigmah.client.ui.view.orgunit.OrgUnitView;
+import org.sigmah.client.ui.view.password.ChangeOwnPasswordView;
+import org.sigmah.client.ui.view.password.LostPasswordView;
+import org.sigmah.client.ui.view.password.ResetPasswordView;
+import org.sigmah.client.ui.view.pivot.ProjectPivotContainer;
+import org.sigmah.client.ui.view.pivot.table.PivotGridPanel;
+import org.sigmah.client.ui.view.project.LinkedProjectView;
+import org.sigmah.client.ui.view.project.ProjectCalendarView;
+import org.sigmah.client.ui.view.project.ProjectDetailsView;
+import org.sigmah.client.ui.view.project.ProjectReportsView;
+import org.sigmah.client.ui.view.project.ProjectTeamMembersView;
+import org.sigmah.client.ui.view.project.ProjectView;
+import org.sigmah.client.ui.view.project.dashboard.PhasesView;
+import org.sigmah.client.ui.view.project.dashboard.ProjectDashboardView;
+import org.sigmah.client.ui.view.project.export.ExportProjectsSettingView;
+import org.sigmah.client.ui.view.project.export.ExportProjectsView;
+import org.sigmah.client.ui.view.project.indicator.EditIndicatorView;
+import org.sigmah.client.ui.view.project.indicator.EditSiteView;
+import org.sigmah.client.ui.view.project.indicator.ProjectIndicatorEntriesView;
+import org.sigmah.client.ui.view.project.indicator.ProjectIndicatorManagementView;
+import org.sigmah.client.ui.view.project.indicator.ProjectIndicatorMapView;
+import org.sigmah.client.ui.view.project.indicator.SiteGridPanel;
+import org.sigmah.client.ui.view.project.logframe.ProjectLogFrameGrid;
+import org.sigmah.client.ui.view.project.logframe.ProjectLogFrameView;
+import org.sigmah.client.ui.view.project.projectcore.ProjectCoreDiffView;
+import org.sigmah.client.ui.view.project.projectcore.ProjectCoreRenameVersionView;
+import org.sigmah.client.ui.view.project.treegrid.ProjectsListView;
+import org.sigmah.client.ui.view.reminder.ReminderEditView;
+import org.sigmah.client.ui.view.reminder.ReminderHistoryView;
+import org.sigmah.client.ui.view.reports.AttachFileView;
+import org.sigmah.client.ui.view.reports.ReportCreateView;
+import org.sigmah.client.ui.view.reports.ReportsView;
+import org.sigmah.client.ui.view.zone.AppLoaderView;
+import org.sigmah.client.ui.view.zone.AuthenticationBannerView;
+import org.sigmah.client.ui.view.zone.MenuBannerView;
+import org.sigmah.client.ui.view.zone.MessageBannerView;
+import org.sigmah.client.ui.view.zone.OfflineBannerView;
+import org.sigmah.client.ui.view.zone.OrganizationBannerView;
+import org.sigmah.client.util.ClientUtils;
+import org.sigmah.client.util.ImageProvider;
+import org.sigmah.offline.dao.AuthenticationAsyncDAO;
+import org.sigmah.offline.dao.CategoryElementAsyncDAO;
+import org.sigmah.offline.dao.CategoryTypeAsyncDAO;
+import org.sigmah.offline.dao.ComputationAsyncDAO;
+import org.sigmah.offline.dao.CountryAsyncDAO;
+import org.sigmah.offline.dao.FileDataAsyncDAO;
+import org.sigmah.offline.dao.HistoryAsyncDAO;
+import org.sigmah.offline.dao.LogFrameAsyncDAO;
+import org.sigmah.offline.dao.LogoAsyncDAO;
+import org.sigmah.offline.dao.MonitoredPointAsyncDAO;
+import org.sigmah.offline.dao.OrgUnitAsyncDAO;
+import org.sigmah.offline.dao.OrgUnitModelAsyncDAO;
+import org.sigmah.offline.dao.OrganizationAsyncDAO;
+import org.sigmah.offline.dao.PageAccessAsyncDAO;
+import org.sigmah.offline.dao.PersonalCalendarAsyncDAO;
+import org.sigmah.offline.dao.PhaseAsyncDAO;
+import org.sigmah.offline.dao.PhaseModelAsyncDAO;
+import org.sigmah.offline.dao.ProfileAsyncDAO;
+import org.sigmah.offline.dao.ProjectAsyncDAO;
+import org.sigmah.offline.dao.ProjectModelAsyncDAO;
+import org.sigmah.offline.dao.ProjectReportAsyncDAO;
+import org.sigmah.offline.dao.ProjectTeamMembersAsyncDAO;
+import org.sigmah.offline.dao.ReminderAsyncDAO;
+import org.sigmah.offline.dao.ReportReferenceAsyncDAO;
+import org.sigmah.offline.dao.TransfertAsyncDAO;
+import org.sigmah.offline.dao.UpdateDiaryAsyncDAO;
+import org.sigmah.offline.dao.UserAsyncDAO;
+import org.sigmah.offline.dao.UserUnitAsyncDAO;
+import org.sigmah.offline.dao.ValueAsyncDAO;
+import org.sigmah.offline.dispatch.LocalDispatchServiceAsync;
+import org.sigmah.offline.fileapi.FileReader;
+import org.sigmah.offline.handler.ActivityCalendarAsyncHandler;
+import org.sigmah.offline.handler.BatchCommandAsyncHandler;
+import org.sigmah.offline.handler.CreateEntityAsyncHandler;
+import org.sigmah.offline.handler.DeleteAsyncHandler;
+import org.sigmah.offline.handler.GetCalendarAsyncHandler;
+import org.sigmah.offline.handler.GetCategoriesAsyncHandler;
+import org.sigmah.offline.handler.GetCountriesAsyncHandler;
+import org.sigmah.offline.handler.GetCountryAsyncHandler;
+import org.sigmah.offline.handler.GetHistoryAsyncHandler;
+import org.sigmah.offline.handler.GetLinkedProjectsAsyncHandler;
+import org.sigmah.offline.handler.GetMonitoredPointsAsyncHandler;
+import org.sigmah.offline.handler.GetOrgUnitAsyncHandler;
+import org.sigmah.offline.handler.GetOrgUnitsAsyncHandler;
+import org.sigmah.offline.handler.GetOrganizationAsyncHandler;
+import org.sigmah.offline.handler.GetProfilesAsyncHandler;
+import org.sigmah.offline.handler.GetProjectAsyncHandler;
+import org.sigmah.offline.handler.GetProjectDocumentsAsyncHandler;
+import org.sigmah.offline.handler.GetProjectReportAsyncHandler;
+import org.sigmah.offline.handler.GetProjectReportsAsyncHandler;
+import org.sigmah.offline.handler.GetProjectTeamMembersAsyncHandler;
+import org.sigmah.offline.handler.GetProjectsAsyncHandler;
+import org.sigmah.offline.handler.GetProjectsFromIdAsyncHandler;
+import org.sigmah.offline.handler.GetRemindersAsyncHandler;
+import org.sigmah.offline.handler.GetSitesCountAsyncHandler;
+import org.sigmah.offline.handler.GetUserUnitsByUserAsyncHandler;
+import org.sigmah.offline.handler.GetUsersByOrgUnitAsyncHandler;
+import org.sigmah.offline.handler.GetUsersByOrganizationAsyncHandler;
+import org.sigmah.offline.handler.GetValueAsyncHandler;
+import org.sigmah.offline.handler.GetValueFromLinkedProjectsAsyncHandler;
+import org.sigmah.offline.handler.MonitoredPointCalendarAsyncHandler;
+import org.sigmah.offline.handler.PersonalCalendarAsyncHandler;
+import org.sigmah.offline.handler.PrepareFileUploadAsyncHandler;
+import org.sigmah.offline.handler.ReminderCalendarAsyncHandler;
+import org.sigmah.offline.handler.SecureNavigationAsyncHandler;
+import org.sigmah.offline.handler.UpdateEntityAsyncHandler;
+import org.sigmah.offline.handler.UpdateLogFrameAsyncHandler;
+import org.sigmah.offline.handler.UpdateMonitoredPointsAsyncHandler;
+import org.sigmah.offline.handler.UpdateProjectAsyncHandler;
+import org.sigmah.offline.handler.UpdateProjectFavoriteAsyncHandler;
+import org.sigmah.offline.handler.UpdateProjectTeamMembersAsyncHandler;
+import org.sigmah.offline.handler.UpdateRemindersAsyncHandler;
+import org.sigmah.offline.indexeddb.IndexedDB;
+import org.sigmah.offline.presenter.FileSelectionPresenter;
+import org.sigmah.offline.status.ApplicationStateManager;
+import org.sigmah.offline.sync.Synchronizer;
+import org.sigmah.offline.view.FileSelectionView;
+import org.sigmah.shared.dto.ContactModelDTO;
+import org.sigmah.shared.dto.IsModel;
+import org.sigmah.shared.dto.OrgUnitModelDTO;
+import org.sigmah.shared.dto.ProjectModelDTO;
+import org.sigmah.shared.dto.pivot.content.GXTStateManager;
+import org.sigmah.shared.dto.pivot.content.IStateManager;
+import org.sigmah.shared.file.DirectTransfertManager;
+import org.sigmah.shared.file.Html5TransfertManager;
+import org.sigmah.shared.file.TransfertManager;
+import org.sigmah.shared.file.TransfertManagerProvider;
+
+import com.google.gwt.core.client.GWT;
+
+public class ClientFactoryImpl implements ClientFactory {
+
+	EventBus eventBus;
+
+	DispatchAsync dispatch;
+
+	LocalDispatchServiceAsync localdispatchAsynch;
+
+	PageManager pageManeger;
+
+	Theme theme;
+
+	AuthenticationProvider authenticationProvider;
+
+	ApplicationStateManager applicationStateManager;
+
+	IStateManager iStateManager;
+
+	TransfertManager TransferManager;
+	
+	public static boolean html5EngineActive = GWT.isProdMode() && (ClientUtils.isFF() || ClientUtils.isSafari() || ClientUtils.isIE10() || ClientUtils.isIE11());
+
+	Synchronizer synchronizer;
+
+	UserLocalCache userLocalCache;
+	
+	ExceptionHandler exceptionHandler;
+
+	// --------------------------------------------------
+	//
+	// Asynchronous DAO (offline mode).
+	//
+	// --------------------------------------------------
+
+	FileDataAsyncDAO fileDataAsyncDAO;
+
+	TransfertAsyncDAO transfertAsyncDAO;
+
+	// --------------------------------------------------
+	//
+	// Presenters.
+	//
+	// --------------------------------------------------
+
+	ApplicationPresenter applicationPresenter;
+
+	// ---- Zones presenters.
+
+	MockUpPresenter mockUpPresenter;
+
+	OrganizationBannerPresenter organizationBannerPresenter;
+
+	AuthenticationBannerPresenter authenticationBannerPresenter;
+
+	OfflineBannerPresenter offlineBannerPresenter;
+
+	AppLoaderPresenter appLoaderPresenter;
+
+	MenuBannerPresenter menuBannerPresenter;
+
+	MessageBannerPresenter messageBannerPresenter;
+
+	CreditsPresenter creditsPresenter;
+
+	HelpPresenter helpPresenter;
+
+	// ---- Pages presenters.
+
+	DashboardPresenter homePresenter;
+
+	LoginPresenter loginPresenter;
+
+	LostPasswordPresenter lostPasswordPresenter;
+
+	ResetPasswordPresenter resetPasswordPresenter;
+
+	ChangeOwnPasswordPresenter changeOwnPasswordPresenter;
+
+	CreateProjectPresenter createProjectPresenter;
+
+	CalendarEventPresenter calendarEventPresenter;
+
+	ReportCreatePresenter reportCreatePresenter;
+
+	AttachFilePresenter attachFilePresenter;
+
+	ImportationPresenter importationPresenter;
+
+	// ---- Project presenters.
+
+	ProjectPresenter projectPresenter;
+
+	ProjectDashboardPresenter projectDashboardPresenter;
+
+	ProjectLogFramePresenter projectLogFramePresenter;
+
+	ProjectDetailsPresenter projectDetailsPresenter;
+
+	ProjectTeamMembersPresenter projectTeamMembersPresenter;
+
+	ProjectCalendarPresenter projectCalendarPresenter;
+
+	ProjectReportsPresenter projectReportsPresenter;
+
+	ReminderEditPresenter reminderEditPresenter;
+
+	ReminderHistoryPresenter reminderHistoryPresenter;
+
+	LinkedProjectPresenter linkedProjectPresenter;
+
+	ProjectIndicatorEntriesPresenter projectIndicatorEntriesPresenter;
+
+	ProjectIndicatorManagementPresenter projectIndicatorManagementPresenter;
+
+	ProjectIndicatorMapPresenter projectIndicatorMapPresenter;
+
+	EditIndicatorPresenter editIndicatorPresenter;
+
+	EditSitePresenter editSitePresenter;
+
+	ExportContactsPresenter exportContactsPresenter;
+
+	ExportContactsSettingPresenter exportContactsSettingPresenter;
+
+	ExportProjectsPresenter exportProjectsPresenter;
+
+	ExportProjectsSettingPresenter exportProjectsSettingPresenter;
+
+	ProjectCoreRenameVersionPresenter projectCoreRenameVersionPresenter;
+
+	ProjectCoreDiffPresenter projectCoreDiffPresenter;
+
+	// ---- OrgUnit presenters.
+
+	OrgUnitPresenter orgUnitPresenter;
+
+	OrgUnitDashboardPresenter orgUnitDashboradPresenter;
+
+	OrgUnitDetailsPresenter orgUnitDetailsPresenter;
+
+	OrgUnitCalendarPresenter orgUnitCalendarPresenter;
+
+	OrgUnitReportsPresenter orgUnitReportsPresenter;
+	
+	OrgUnitAsyncDAO orgUnitAsyncDAO;
+
+	// ---- Contact presenters
+
+	ContactPresenter contactPresenter;
+
+	ContactDetailsPresenter contactDetailsPresenter;
+
+	ContactRelationshipsPresenter contactRelationshipsPresenter;
+
+	ContactHistoryPresenter ContactHistoryPresenter;
+
+	// ---- Admin presenters
+
+	AdminPresenter adminPresenter;
+
+	ParametersAdminPresenter parametersAdminPresenter;
+
+	UsersAdminPresenter usersAdminPresenter;
+
+	PrivacyGroupEditPresenter privacyGroupEditPresenter;
+
+	ProfileEditPresenter profileEditPresenter;
+
+	UserEditPresenter userEditPresenter;
+
+	OrgUnitsAdminPresenter orgUnitsAdminPresenter;
+
+	AddOrgUnitAdminPresenter addOrgUnitAdminPresenter;
+
+	MoveOrgUnitAdminPresenter moveOrgUnitAdminPresenter;
+
+	CategoriesAdminPresenter categoriesAdminPresenter;
+
+	OrgUnitModelsAdminPresenter orgUnitModelsAdminPresenter;
+
+	AddOrgUnitModelAdminPresenter addOrgUnitModelAdminPresenter;
+
+	ProjectModelsAdminPresenter projectModelsAdminPresenter;
+
+	AddProjectModelAdminPresenter addProjectModelAdminPresenter;
+
+	ContactModelsAdminPresenter contactModelsAdminPresenter;
+
+	AddContactModelAdminPresenter addContactModelAdminPresenter;
+
+	AddImportationSchemePresenter addImportationSchemePresenter;
+
+	ReportModelsAdminPresenter reportModelsAdminPresenter;
+
+	EditPhaseModelAdminPresenter editPhaseModelAdminPresenter;
+
+	EditLayoutGroupAdminPresenter editLayoutGroupAdminPresenter;
+
+	EditFlexibleElementAdminPresenter editFlexibleElementAdminPresenter;
+
+	AddBudgetSubFieldPresenter addBudSubFieldPresenter;
+
+	ImportModelPresenter importModelPresenter;
+
+	ImportationSchemeAdminPresenter importationShemePresenter;
+
+	AddVariableImporationSchemePresenter addVariableImporationSchemePresenter;
+
+	AddImportationSchemeModelsAdminPresenter addImportationSchemeModelsAdminPresenter;
+
+	AddMatchingRuleImportationShemeModelsAdminPresenter addMatchingRuleImportationShemeModelsAdminPresenter;
+
+	UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
+
+	// ---- Offline presenters
+
+	FileSelectionPresenter fileSelectionPresenter;
+
+	TransfertManagerProvider transferManagerProvider;
+
+	MonitoredPointAsyncDAO monitoredPointAsyncDAO;
+
+	ReminderAsyncDAO reminderAsyncDAO;
+
+	ImageProvider provider;
+
+	LogoAsyncDAO logoAsyncDAO;
+
+	AuthenticationBannerView authenticationBannerView;
+
+	//// Views
+	ProjectDashboardView projectDashboardView;
+
+	ProjectLogFrameView projectLogFrameView;
+
+	ProjectDetailsView projectDetailsView;
+
+	ProjectTeamMembersView projectTeamMembersView;
+
+	ProjectCalendarView projectCalendarView;
+
+	ProjectReportsView projectReportsView;
+
+	ReminderEditView reminderEditView;
+
+	ReminderHistoryView reminderHistoryView;
+
+	LinkedProjectView linkedProjectView;
+
+	ProjectIndicatorEntriesView projectIndicatorEntriesView;
+
+	ProjectIndicatorManagementView projectIndicatorManagementView;
+
+	ProjectIndicatorMapView projectIndicatorMapView;
+
+	EditIndicatorView editIndicatorView;
+
+	EditSiteView editSiteView;
+
+	ExportContactsView exportContactsView;
+
+	ExportContactsSettingView exportContactsSettingView;
+
+	ExportProjectsView exportProjectsView;
+
+	ExportProjectsSettingView exportProjectsSettingView;
+
+	ProjectCoreRenameVersionView projectCoreRenameVersionView;
+
+	ProjectCoreDiffView projectCoreDiffView;
+
+	OrgUnitView orgUnitView;
+
+	OrgUnitDashboardView orgUnitDashboardView;
+
+	OrgUnitDetailsView orgUnitDetailsView;
+
+	OrgUnitCalendarView orgUnitCalendarView;
+
+	OrgUnitReportsView orgUnitReportsView;
+
+	ContactView contactView;
+
+	ContactDetailsView contactDetailsView;
+
+	ContactRelationshipsView contactRelationshipsView;
+
+	ContactHistoryView contactHistoryView;
+
+	AdminView adminView;
+
+	ParametersAdminView parametersAdminView;
+
+	UsersAdminView usersAdminView;
+
+	PrivacyGroupEditView privacyGroupEditView;
+
+	ProfileEditView profileEditView;
+
+	UserEditView userEditView;
+
+	OrgUnitsAdminView orgUnitsAdminView;
+
+	AddOrgUnitAdminView addOrgUnitAdminView;
+
+	MoveOrgUnitAdminView moveOrgUnitAdminView;
+
+	CategoriesAdminView categoriesAdminView;
+
+	OrgUnitModelsAdminView orgUnitModelsAdminView;
+
+	AddOrgUnitModelAdminView addOrgUnitModelAdminView;
+
+	ProjectModelsAdminView projectModelsAdminView;
+
+	AddProjectModelAdminView addProjectModelAdminView;
+
+	ContactModelsAdminView contactModelsAdminView;
+
+	AddContactModelAdminView addContactModelAdminView;
+
+	AddImportationSchemeView addImportationSchemeView;
+
+	ReportModelsAdminView reportModelsAdminView;
+
+	EditPhaseModelAdminView editPhaseModelAdminView;
+
+	EditLayoutGroupAdminView editLayoutGroupAdminView;
+
+	EditFlexibleElementAdminView editFlexibleElementAdminView;
+
+	AddBudgetSubFieldView addBudSubFieldView;
+
+	ImportModelView importModelView;
+
+	ImportationSchemeAdminView importationSchemeAdminView;
+
+	AddVariableImporationSchemeView addVariableImporationSchemeView;
+
+	AddImportationSchemeModelsAdminView addImportationSchemeModelsAdminView;
+
+	AddMatchingRuleImportationShemeModelsAdminView addMatchingRuleImportationShemeModelsAdminView;
+
+	ProjectLogFrameGrid projectLogFrameGrid;
+
+	FileSelectionView fileSelectionView;
+
+	ProjectPivotContainer projectPivotContainer;
+
+	PivotGridPanel pivotGridPanel;
+
+	SiteGridPanel siteGridPanel;
+
+	ComputationTriggerManager computationTriggerManager;
+
+	ClientValueResolver clientValueResolver;
+
+	ReportsPresenter reportsPresenter;
+
+	ReportsView reportsView;
+	
+	CalendarPresenter calendarPresenter;
+	
+	CalendarView calendarView;
+	
+	FlexibleElementsAdminPresenter<OrgUnitModelDTO> flexibleElementsAdminPresenter;
+	
+	FlexibleElementsAdminPresenter<ProjectModelDTO> flexibleElementsAdminPresenter2;
+	
+	FlexibleElementsAdminView flexibleElementsAdminView;
+	
+	 ImportationSchemeModelsAdminView importationSchemeModelsAdminView;
+	    
+	ImportationSchemeModelsAdminPresenter<OrgUnitModelDTO> importationSchemeModelsAdminPresenter;
+	
+	PhaseModelsAdminPresenter phaseModelsAdminPresenter;
+	
+	PhaseModelsAdminView phaseModelsAdminView;
+	
+	LogFrameModelsAdminPresenter logFrameModelsAdminPresenter;
+	 
+	LogFrameModelsAdminView logFrameModelsAdminView;
+	
+	ImportationSchemeModelsAdminPresenter<ProjectModelDTO> importationSchemeModelsAdminPresenter2;
+	
+	FlexibleElementsAdminPresenter<ContactModelDTO> flexibleElementsAdminPresenter3;
+	
+	ProjectAsyncDAO projectAsyncDAO;
+	
+	ApplicationView applicationView;
+	
+	MockUpView mockupView;
+	
+	OrganizationBannerView organizationBannerView;
+	
+	ImageProvider imageProvider;
+	
+	MessageBannerView messageBannerView;
+
+	CreditsView creditsView;
+
+	HelpView helpView;
+
+	ContactsListView contactsListView;
+
+	ProjectsListView projectsListView;
+
+	DashboardView dashboardView;
+
+	LoginView loginView;
+
+	LostPasswordView lostPasswordView;
+
+	ResetPasswordView resetPasswordView;
+
+	ChangeOwnPasswordView changeOwnPasswordView;
+
+	CreateProjectView createProjectView;
+
+	CalendarEventView calendarEventView;
+
+	ReportCreateView reportCreateView;
+
+	AttachFileView attachFileView;
+
+	ImportationView importationView;
+
+	ProjectView projectView;
+
+	ProjectModelAsyncDAO projectModelAsyncDAO;
+
+	PhaseAsyncDAO phaseAsyncDAO;
+
+	LogFrameAsyncDAO logFrameAsyncDAO;
+
+	ValueAsyncDAO valueAsyncDAO;
+
+	OrgUnitModelAsyncDAO orgUnitModelAsyncDAO;
+
+	CountryAsyncDAO countryAsyncDAO;
+	
+	OfflineBannerView offlineBannerView;
+	
+	AppLoaderView appLoaderView;
+	
+	MenuBannerView menuBannerView;
+	
+	PhaseModelAsyncDAO phaseModelAsyncDAO;
+	
+	ComputationAsyncDAO computationAsyncDAO;
+	
+	BatchCommandAsyncHandler batchCommandAsyncHandler;
+
+	CreateEntityAsyncHandler createEntityAsyncHandler;
+
+	DeleteAsyncHandler deleteAsyncHandler;
+
+	GetCalendarAsyncHandler getCalendarAsyncHandler;
+
+	GetCategoriesAsyncHandler getCategoriesAsyncHandler;
+
+	GetCountriesAsyncHandler getCountriesAsyncHandler;
+
+	GetCountryAsyncHandler getCountryAsyncHandler;
+
+	GetHistoryAsyncHandler getHistoryAsyncHandler;
+
+	GetLinkedProjectsAsyncHandler getLinkedProjectsAsyncHandler;
+
+	GetMonitoredPointsAsyncHandler getMonitoredPointsAsyncHandler;
+
+	GetOrganizationAsyncHandler getOrganizationAsyncHandler;
+
+	GetOrgUnitAsyncHandler getOrgUnitAsyncHandler;
+
+	GetOrgUnitsAsyncHandler getOrgUnitsAsyncHandler;
+
+	GetProfilesAsyncHandler getProfilesAsyncHandler;
+
+	GetProjectAsyncHandler getProjectAsyncHandler;
+
+	GetProjectsAsyncHandler getProjectsAsyncHandler;
+
+	GetProjectsFromIdAsyncHandler getProjectsFromIdAsyncHandler;
+
+	GetProjectDocumentsAsyncHandler getProjectDocumentsAsyncHandler;
+
+	GetProjectReportAsyncHandler getProjectReportAsyncHandler;
+
+	GetProjectReportsAsyncHandler getProjectReportsAsyncHandler;
+
+	GetProjectTeamMembersAsyncHandler getProjectTeamMembersAsyncHandler;
+
+	GetRemindersAsyncHandler getRemindersAsyncHandler;
+
+	GetSitesCountAsyncHandler getSitesCountAsyncHandler;
+
+	GetUsersByOrganizationAsyncHandler getUsersByOrganizationAsyncHandler;
+
+	GetUsersByOrgUnitAsyncHandler getUsersByOrgUnitAsyncHandler;
+
+	GetUserUnitsByUserAsyncHandler getUserUnitsByUserAsyncHandler;
+
+	GetValueAsyncHandler getValueAsyncHandler;
+
+	GetValueFromLinkedProjectsAsyncHandler getValueFromLinkedProjectsAsyncHandler;
+
+	PrepareFileUploadAsyncHandler prepareFileUploadAsyncHandler;
+
+	SecureNavigationAsyncHandler secureNavigationAsyncHandler;
+
+	UpdateEntityAsyncHandler updateEntityAsyncHandler;
+
+	UpdateLogFrameAsyncHandler updateLogFrameAsyncHandler;
+
+	UpdateMonitoredPointsAsyncHandler updateMonitoredPointsAsyncHandler;
+
+	UpdateProjectAsyncHandler updateProjectAsyncHandler;
+
+	UpdateProjectFavoriteAsyncHandler updateProjectFavoriteAsyncHandler;
+
+	UpdateProjectTeamMembersAsyncHandler updateProjectTeamMembersAsyncHandler;
+
+	UpdateRemindersAsyncHandler updateRemindersAsyncHandler;
+	
+	PersonalCalendarAsyncDAO personalCalendarAsyncDAO;
+	
+
+	 ActivityCalendarAsyncHandler activityCalendarAsyncHandler; 
+
+	
+	 PersonalCalendarAsyncHandler personalCalendarAsyncHandler; 
+
+	
+	 MonitoredPointCalendarAsyncHandler monitoredPointCalendarAsyncHandler; 
+
+	
+	 ReminderCalendarAsyncHandler reminderCalendarAsyncHandler; 
+
+	
+	 org.sigmah.offline.dao.CategoryTypeAsyncDAO categoryTypeAsyncDAO; 
+
+	
+	 HistoryAsyncDAO historyAsyncDAO; 
+
+	
+	 OrganizationAsyncDAO organizationAsyncDAO; 
+
+	
+	 ProfileAsyncDAO profileAsyncDAO; 
+
+	
+	 UserAsyncDAO userAsyncDAO; 
+
+	
+	 UserUnitAsyncDAO userUnitAsyncDAO; 
+
+	
+	 AuthenticationAsyncDAO authenticationAsyncDAO; 
+
+	
+	 PageAccessAsyncDAO pageAccessAsyncDAO; 
+
+	
+	 ProjectReportAsyncDAO projectReportAsyncDAO; 
+
+	
+	 ProjectTeamMembersAsyncDAO projectTeamMembersAsyncDAO;
+
+	 ReportReferenceAsyncDAO reportReferenceAsyncDAO;
+	 
+	 CategoryElementAsyncDAO categoryElementAsyncDAO;
+
+	@Override
+	public EventBus getEventBus() {
+		if (eventBus == null)
+			eventBus = new EventBusImpl(this);
+
+		return eventBus;
+	}
+
+	@Override
+	public DispatchAsync getDispatch() {
+		if (dispatch == null){
+			dispatch = new SecureDispatchAsync(getAuthenticationProvider(), getEventBus(), getPageManager(),
+					getApplicationStateManager(), getExceptionHandler());
+		}
+		
+		return dispatch;
+	}
+
+	@Override
+	public LocalDispatchServiceAsync getLocalDispatch() {
+		if (localdispatchAsynch == null)
+			localdispatchAsynch = new LocalDispatchServiceAsync(getAuthenticationProvider());
+		return localdispatchAsynch;
+	}
+
+	@Override
+	public PageManager getPageManager() {
+		if (pageManeger == null) {
+
+			pageManeger = new PageManager(getEventBus());
+		}
+		return pageManeger;
+	}
+
+	@Override
+	public Theme getTheme() {
+		if (theme == null) {
+			theme = new SigmahTheme();
+		}
+
+		return theme;
+	}
+
+	@Override
+	public AuthenticationProvider getAuthenticationProvider() {
+		if (authenticationProvider == null) {
+
+			authenticationProvider = new AuthenticationProvider();
+		}
+		return authenticationProvider;
+	}
+
+	@Override
+	public ApplicationStateManager getApplicationStateManager() {
+		if (applicationStateManager == null) {
+
+			applicationStateManager = new ApplicationStateManager(getEventBus(), getUpdateDiaryAsyncDAO());
+		}
+		return applicationStateManager;
+	}
+
+	@Override
+	public TransfertManager getTransfertManager() {
+		if (TransferManager == null) {
+			 DirectTransfertManager directTransfertManager = new DirectTransfertManager(getAuthenticationProvider(), getPageManager(), getEventBus());
+			if (html5EngineActive && IndexedDB.isSupported() && FileReader.isSupported()) {
+				TransferManager = new Html5TransfertManager(getDispatch(), getFileDataAsyncDAO(), getTransfertAsyncDAO(), getEventBus(), directTransfertManager);
+		      } else {
+		    	  TransferManager = directTransfertManager;
+		      }
+
+		}
+		return TransferManager;
+	}
+
+	@Override
+	public Synchronizer getSynchronizer() {
+		if (synchronizer == null)
+			synchronizer = new Synchronizer(getUpdateDiaryAsyncDAO(), getReminderAsyncDAO(),
+					getMonitoredPointAsyncDAO(), getTransfertAsyncDAO(), getFileDataAsyncDAO(), getDispatch(),
+					getOrgUnitAsyncDAO());
+		return synchronizer;
+	}
+
+	@Override
+	public UserLocalCache getClientCache() {
+		if (userLocalCache == null) {
+
+			userLocalCache = new UserLocalCache(getDispatch(), getLocalDispatch(), getAuthenticationProvider());
+		}
+		return userLocalCache;
+	}
+
+	@Override
+	public FileDataAsyncDAO getFileDataAsyncDAO() {
+		if (fileDataAsyncDAO == null)
+			fileDataAsyncDAO = new FileDataAsyncDAO();
+		return fileDataAsyncDAO;
+	}
+
+	@Override
+	public TransfertAsyncDAO getTransfertAsyncDAO() {
+		if (transfertAsyncDAO == null)
+			transfertAsyncDAO = new TransfertAsyncDAO();
+		return transfertAsyncDAO;
+	}
+
+	@Override
+	public ApplicationPresenter getApplicationPresenter() {
+		if (applicationPresenter == null)
+			applicationPresenter = new ApplicationPresenter(getApplicationView(), this);
+		return applicationPresenter;
+	}
+
+	@Override
+	public MockUpPresenter getMockUpPresenter() {
+		if (mockUpPresenter == null)
+			mockUpPresenter = new MockUpPresenter(getMockUpView(), this);
+		return mockUpPresenter;
+	}
+
+	@Override
+	public OrganizationBannerPresenter getOrganizationBannerPresenter() {
+		if (organizationBannerPresenter == null)
+			organizationBannerPresenter = new OrganizationBannerPresenter(getOrganizationBannerView(), this,
+					getLogoAsyncDAO(), getImageProvider());
+		return organizationBannerPresenter;
+	}
+
+	@Override
+	public AuthenticationBannerPresenter getAuthenticationBannerPresenter() {
+		if (authenticationBannerPresenter == null)
+			authenticationBannerPresenter = new AuthenticationBannerPresenter(getAuthenticationBannerView(), this);
+		return authenticationBannerPresenter;
+	}
+
+	@Override
+	public OfflineBannerPresenter getOfflineBannerPresenter() {
+
+		if (offlineBannerPresenter == null)
+			offlineBannerPresenter = new OfflineBannerPresenter(getOfflineBannerView(), this, getTransfertManager());
+
+		return offlineBannerPresenter;
+	}
+
+	@Override
+	public AppLoaderPresenter getAppLoaderPresenter() {
+
+		if (appLoaderPresenter == null)
+			appLoaderPresenter = new AppLoaderPresenter(getAppLoaderView(), this);
+
+		return appLoaderPresenter;
+	}
+
+	@Override
+	public MenuBannerPresenter getMenuBannerPresenter() {
+		if (menuBannerPresenter == null)
+			menuBannerPresenter = new MenuBannerPresenter(getMenuBannerView(), this);
+		return menuBannerPresenter;
+	}
+
+	@Override
+	public MessageBannerPresenter getMessageBannerPresenter() {
+		if (messageBannerPresenter == null)
+			messageBannerPresenter = new MessageBannerPresenter(getMessageBannerView(), this);
+		return messageBannerPresenter;
+	}
+
+	@Override
+	public CreditsPresenter getCreditsPresenter() {
+
+		if (creditsPresenter == null)
+			creditsPresenter = new CreditsPresenter(getCreditsView(), this);
+
+		return creditsPresenter;
+	}
+
+	@Override
+	public HelpPresenter getHelpPresenter() {
+		if (helpPresenter == null)
+			helpPresenter = new HelpPresenter(getHelpView(), this);
+		return helpPresenter;
+	}
+
+	@Override
+	public DashboardPresenter getHomePresenter() {
+
+		if (homePresenter == null)
+			homePresenter = new DashboardPresenter(getDashboardView(), this);
+
+		return homePresenter;
+	}
+
+	@Override
+	public LoginPresenter getLoginPresenter() {
+
+		if (loginPresenter == null)
+			loginPresenter = new LoginPresenter(getLoginView(), this);
+		return loginPresenter;
+	}
+
+	@Override
+	public LostPasswordPresenter getLostPasswordPresenter() {
+
+		if (lostPasswordPresenter == null)
+			lostPasswordPresenter = new LostPasswordPresenter(getLostPasswordView(), this);
+		return lostPasswordPresenter;
+	}
+
+	@Override
+	public ResetPasswordPresenter getResetPasswordPresenter() {
+		if (resetPasswordPresenter == null)
+			resetPasswordPresenter = new ResetPasswordPresenter(getResetPasswordView(), this);
+
+		return null;
+	}
+
+	@Override
+	public ChangeOwnPasswordPresenter getChangeOwnPasswordPresenter() {
+
+		if (changeOwnPasswordPresenter == null)
+			changeOwnPasswordPresenter = new ChangeOwnPasswordPresenter(getChangeOwnPasswordView(), this);
+
+		return changeOwnPasswordPresenter;
+	}
+
+	@Override
+	public CreateProjectPresenter getCreateProjectPresenter() {
+
+		if (createProjectPresenter == null)
+			createProjectPresenter = new CreateProjectPresenter(getCreateProjectView(), this);
+
+		return createProjectPresenter;
+	}
+
+	@Override
+	public CalendarEventPresenter getCalendarEventPresenter() {
+
+		if (calendarEventPresenter == null)
+			calendarEventPresenter = new CalendarEventPresenter(getCalendarEventView(), this);
+
+		return calendarEventPresenter;
+	}
+
+	@Override
+	public ReportCreatePresenter getReportCreatePresenter() {
+
+		if (reportCreatePresenter == null)
+			reportCreatePresenter = new ReportCreatePresenter(getReportCreateView(), this);
+
+		return reportCreatePresenter;
+	}
+
+	@Override
+	public AttachFilePresenter getAttachFilePresenter() {
+
+		if (attachFilePresenter == null)
+			attachFilePresenter = new AttachFilePresenter(getAttachFileView(), this);
+
+		return attachFilePresenter;
+
+	}
+
+	@Override
+	public ImportationPresenter getImportationPresenter() {
+
+		if (importationPresenter == null)
+			importationPresenter = new ImportationPresenter(getImportationView(), this);
+
+		return importationPresenter;
+	}
+
+	@Override
+	public ProjectPresenter getProjectPresenter() {
+		if (projectPresenter == null)
+			projectPresenter = new ProjectPresenter(getProjectView(), this);
+
+		return projectPresenter;
+	}
+
+	/////////////// start from here
+
+	@Override
+	public ProjectDashboardPresenter getProjectDashboardPresenter() {
+		if (projectDashboardPresenter == null)
+			projectDashboardPresenter = new ProjectDashboardPresenter(getProjectDashboardView(), this);
+
+		return projectDashboardPresenter;
+	}
+
+	@Override
+	public ProjectLogFramePresenter getProjectLogFramePresenter() {
+		if (projectLogFramePresenter == null)
+			projectLogFramePresenter = new ProjectLogFramePresenter(getProjectLogFrameView(), this);
+
+		return projectLogFramePresenter;
+	}
+
+	@Override
+	public ProjectDetailsPresenter getProjectDetailsPresenter() {
+		if (projectDetailsPresenter == null)
+			projectDetailsPresenter = new ProjectDetailsPresenter(getProjectDetailsView(), this);
+
+		return projectDetailsPresenter;
+	}
+
+	@Override
+	public ProjectTeamMembersPresenter getProjectTeamMembersPresenter() {
+		if (projectTeamMembersPresenter == null)
+			projectTeamMembersPresenter = new ProjectTeamMembersPresenter(getProjectTeamMembersView(), this);
+
+		return projectTeamMembersPresenter;
+	}
+
+	@Override
+	public ProjectCalendarPresenter getProjectCalendarPresenter() {
+		if (projectCalendarPresenter == null)
+			projectCalendarPresenter = new ProjectCalendarPresenter(getProjectCalendarView(), this);
+
+		return projectCalendarPresenter;
+	}
+
+	@Override
+	public ProjectReportsPresenter getProjectReportsPresenter() {
+		if (projectReportsPresenter == null)
+			projectReportsPresenter = new ProjectReportsPresenter(getProjectReportsView(), this);
+
+		return projectReportsPresenter;
+	}
+
+	@Override
+	public ReminderEditPresenter getReminderEditPresenter() {
+		if (reminderEditPresenter == null)
+			reminderEditPresenter = new ReminderEditPresenter(getReminderEditView(), this);
+
+		return reminderEditPresenter;
+	}
+
+	@Override
+	public ReminderHistoryPresenter getReminderHistoryPresenter() {
+		if (reminderHistoryPresenter == null)
+			reminderHistoryPresenter = new ReminderHistoryPresenter(getReminderHistoryView(), this);
+
+		return reminderHistoryPresenter;
+	}
+
+	@Override
+	public LinkedProjectPresenter getLinkedProjectPresenter() {
+		if (linkedProjectPresenter == null)
+			linkedProjectPresenter = new LinkedProjectPresenter(getLinkedProjectView(), this);
+
+		return linkedProjectPresenter;
+	}
+
+	@Override
+	public ProjectIndicatorEntriesPresenter getProjectIndicatorEntriesPresenter() {
+		if (projectIndicatorEntriesPresenter == null)
+			projectIndicatorEntriesPresenter = new ProjectIndicatorEntriesPresenter(getProjectIndicatorEntriesView(),
+					this);
+
+		return projectIndicatorEntriesPresenter;
+	}
+
+	@Override
+	public ProjectIndicatorManagementPresenter getProjectIndicatorManagementPresenter() {
+		if (projectIndicatorManagementPresenter == null)
+			projectIndicatorManagementPresenter = new ProjectIndicatorManagementPresenter(
+					getProjectIndicatorManagementView(), this);
+
+		return projectIndicatorManagementPresenter;
+	}
+
+	@Override
+	public ProjectIndicatorMapPresenter getProjectIndicatorMapPresenter() {
+		if (projectIndicatorMapPresenter == null)
+			projectIndicatorMapPresenter = new ProjectIndicatorMapPresenter(getProjectIndicatorMapView(), this);
+
+		return projectIndicatorMapPresenter;
+	}
+
+	@Override
+	public EditIndicatorPresenter getEditIndicatorPresenter() {
+		if (editIndicatorPresenter == null)
+			editIndicatorPresenter = new EditIndicatorPresenter(getEditIndicatorView(), this);
+
+		return editIndicatorPresenter;
+	}
+
+	@Override
+	public EditSitePresenter getEditSitePresenter() {
+		if (editSitePresenter == null)
+			editSitePresenter = new EditSitePresenter(getEditSiteView(), this);
+
+		return editSitePresenter;
+	}
+
+	@Override
+	public ExportContactsPresenter getExportContactsPresenter() {
+		if (exportContactsPresenter == null)
+			exportContactsPresenter = new ExportContactsPresenter(getExportContactsView(), this);
+
+		return exportContactsPresenter;
+	}
+
+	@Override
+	public ExportContactsSettingPresenter getExportContactsSettingPresenter() {
+		if (exportContactsSettingPresenter == null)
+			exportContactsSettingPresenter = new ExportContactsSettingPresenter(getExportContactsSettingView(), this);
+
+		return exportContactsSettingPresenter;
+	}
+
+	@Override
+	public ExportProjectsPresenter getExportProjectsPresenter() {
+		if (exportProjectsPresenter == null)
+			exportProjectsPresenter = new ExportProjectsPresenter(getExportProjectsView(), this);
+
+		return exportProjectsPresenter;
+	}
+
+	@Override
+	public ExportProjectsSettingPresenter getExportProjectsSettingPresenter() {
+		if (exportProjectsSettingPresenter == null)
+			exportProjectsSettingPresenter = new ExportProjectsSettingPresenter(getExportProjectsSettingView(), this);
+
+		return exportProjectsSettingPresenter;
+	}
+
+	@Override
+	public ProjectCoreRenameVersionPresenter getProjectCoreRenameVersionPresenter() {
+		if (projectCoreRenameVersionPresenter == null)
+			projectCoreRenameVersionPresenter = new ProjectCoreRenameVersionPresenter(getProjectCoreRenameVersionView(),
+					this);
+
+		return projectCoreRenameVersionPresenter;
+	}
+
+	@Override
+	public ProjectCoreDiffPresenter getProjectCoreDiffPresenter() {
+		if (projectCoreDiffPresenter == null)
+			projectCoreDiffPresenter = new ProjectCoreDiffPresenter(getProjectCoreDiffView(), this);
+
+		return projectCoreDiffPresenter;
+	}
+
+	@Override
+	public OrgUnitPresenter getOrgUnitPresenter() {
+		if (orgUnitPresenter == null)
+			orgUnitPresenter = new OrgUnitPresenter(getOrgUnitView(), this);
+
+		return orgUnitPresenter;
+	}
+
+	@Override
+	public OrgUnitDashboardPresenter getOrgUnitDashboardPresenter() {
+
+		if (orgUnitDashboradPresenter == null)
+			orgUnitDashboradPresenter = new OrgUnitDashboardPresenter(getOrgUnitDashboardView(), this);
+
+		return orgUnitDashboradPresenter;
+	}
+
+	@Override
+	public OrgUnitDetailsPresenter getOrgUnitDetailsPresenter() {
+		if (orgUnitDetailsPresenter == null)
+			orgUnitDetailsPresenter = new OrgUnitDetailsPresenter(getOrgUnitDetailsView(), this);
+
+		return orgUnitDetailsPresenter;
+	}
+
+	@Override
+	public OrgUnitCalendarPresenter getOrgUnitCalendarPresenter() {
+		if (orgUnitCalendarPresenter == null)
+			orgUnitCalendarPresenter = new OrgUnitCalendarPresenter(getOrgUnitCalendarView(), this);
+
+		return orgUnitCalendarPresenter;
+	}
+
+	@Override
+	public OrgUnitReportsPresenter getOrgUnitReportsPresenter() {
+		if (orgUnitReportsPresenter == null)
+			orgUnitReportsPresenter = new OrgUnitReportsPresenter(getOrgUnitReportsView(), this);
+
+		return orgUnitReportsPresenter;
+	}
+
+	@Override
+	public ContactPresenter getContactPresenter() {
+		if (contactPresenter == null)
+			contactPresenter = new ContactPresenter(getContactView(), this, getContactDetailsPresenter(), getContactRelationshipsPresenter(), getContactHistoryPresenter(), getImageProvider());
+
+		return contactPresenter;
+	}
+
+	@Override
+	public ContactDetailsPresenter getContactDetailsPresenter() {
+		if (contactDetailsPresenter == null)
+			contactDetailsPresenter = new ContactDetailsPresenter(getContactDetailsView(), this);
+
+		return contactDetailsPresenter;
+	}
+
+	@Override
+	public ContactRelationshipsPresenter getContactRelationshipsPresenter() {
+		if (contactRelationshipsPresenter == null)
+			contactRelationshipsPresenter = new ContactRelationshipsPresenter(getContactRelationshipsView(), this);
+
+		return contactRelationshipsPresenter;
+	}
+
+	@Override
+	public ContactHistoryPresenter getContactHistoryPresenter() {
+		if (ContactHistoryPresenter == null)
+			ContactHistoryPresenter = new ContactHistoryPresenter(getContactHistoryView(), this);
+
+		return ContactHistoryPresenter;
+	}
+
+	@Override
+	public AdminPresenter getAdminPresenter() {
+		if (adminPresenter == null)
+			adminPresenter = new AdminPresenter(getAdminView(), this);
+
+		return adminPresenter;
+	}
+
+	@Override
+	public ParametersAdminPresenter getParametersAdminPresenter() {
+		if (parametersAdminPresenter == null)
+			parametersAdminPresenter = new ParametersAdminPresenter(getParametersAdminView(), this);
+
+		return parametersAdminPresenter;
+	}
+
+	@Override
+	public UsersAdminPresenter getUsersAdminPresenter() {
+		if (usersAdminPresenter == null)
+			usersAdminPresenter = new UsersAdminPresenter(getUsersAdminView(), this);
+
+		return usersAdminPresenter;
+	}
+
+	@Override
+	public PrivacyGroupEditPresenter getPrivacyGroupEditPresenter() {
+		if (privacyGroupEditPresenter == null)
+			privacyGroupEditPresenter = new PrivacyGroupEditPresenter(getPrivacyGroupEditView(), this);
+
+		return privacyGroupEditPresenter;
+	}
+
+	@Override
+	public ProfileEditPresenter getProfileEditPresenter() {
+		if (profileEditPresenter == null)
+			profileEditPresenter = new ProfileEditPresenter(getProfileEditView(), this);
+
+		return profileEditPresenter;
+	}
+
+	@Override
+	public UserEditPresenter getUserEditPresenter() {
+		if (userEditPresenter == null)
+			userEditPresenter = new UserEditPresenter(getUserEditView(), this);
+
+		return userEditPresenter;
+	}
+
+	@Override
+	public OrgUnitsAdminPresenter getOrgUnitsAdminPresenter() {
+		if (orgUnitsAdminPresenter == null)
+			orgUnitsAdminPresenter = new OrgUnitsAdminPresenter(getOrgUnitsAdminView(), this);
+
+		return orgUnitsAdminPresenter;
+	}
+
+	@Override
+	public AddOrgUnitAdminPresenter getAddOrgUnitAdminPresenter() {
+		if (addOrgUnitAdminPresenter == null)
+			addOrgUnitAdminPresenter = new AddOrgUnitAdminPresenter(getAddOrgUnitAdminView(), this);
+
+		return addOrgUnitAdminPresenter;
+	}
+
+	@Override
+	public MoveOrgUnitAdminPresenter getMoveOrgUnitAdminPresenter() {
+		if (moveOrgUnitAdminPresenter == null)
+			moveOrgUnitAdminPresenter = new MoveOrgUnitAdminPresenter(getMoveOrgUnitAdminView(), this);
+
+		return moveOrgUnitAdminPresenter;
+	}
+
+	@Override
+	public CategoriesAdminPresenter getCategoriesAdminPresenter() {
+		if (categoriesAdminPresenter == null)
+			categoriesAdminPresenter = new CategoriesAdminPresenter(getCategoriesAdminView(), this);
+
+		return categoriesAdminPresenter;
+	}
+
+	@Override
+	public OrgUnitModelsAdminPresenter getOrgUnitModelsAdminPresenter() {
+		if (orgUnitModelsAdminPresenter == null)
+			orgUnitModelsAdminPresenter = new OrgUnitModelsAdminPresenter(getOrgUnitModelsAdminView(), this);
+
+		return orgUnitModelsAdminPresenter;
+	}
+
+	@Override
+	public AddOrgUnitModelAdminPresenter getAddOrgUnitModelAdminPresenter() {
+		if (addOrgUnitModelAdminPresenter == null)
+			addOrgUnitModelAdminPresenter = new AddOrgUnitModelAdminPresenter(getAddOrgUnitModelAdminView(), this);
+
+		return addOrgUnitModelAdminPresenter;
+	}
+
+	@Override
+	public ProjectModelsAdminPresenter getProjectModelsAdminPresenter() {
+		if (projectModelsAdminPresenter == null)
+			projectModelsAdminPresenter = new ProjectModelsAdminPresenter(getProjectModelsAdminView(), this);
+
+		return projectModelsAdminPresenter;
+	}
+
+	@Override
+	public AddProjectModelAdminPresenter getAddProjectModelAdminPresenter() {
+		if (addProjectModelAdminPresenter == null)
+			addProjectModelAdminPresenter = new AddProjectModelAdminPresenter(getAddProjectModelAdminView(), this);
+
+		return addProjectModelAdminPresenter;
+	}
+
+	@Override
+	public ContactModelsAdminPresenter getContactModelsAdminPresenter() {
+		if (contactModelsAdminPresenter == null)
+			contactModelsAdminPresenter = new ContactModelsAdminPresenter(getContactModelsAdminView(), this);
+
+		return contactModelsAdminPresenter;
+	}
+
+	@Override
+	public AddContactModelAdminPresenter getAddContactModelAdminPresenter() {
+		if (addContactModelAdminPresenter == null)
+			addContactModelAdminPresenter = new AddContactModelAdminPresenter(getAddContactModelAdminView(), this);
+
+		return addContactModelAdminPresenter;
+	}
+
+	@Override
+	public AddImportationSchemePresenter getAddImportationSchemePresenter() {
+		if (addImportationSchemePresenter == null)
+			addImportationSchemePresenter = new AddImportationSchemePresenter(getAddImportationSchemeView(), this);
+
+		return addImportationSchemePresenter;
+	}
+
+	@Override
+	public ReportModelsAdminPresenter getReportModelsAdminPresenter() {
+		if (reportModelsAdminPresenter == null)
+			reportModelsAdminPresenter = new ReportModelsAdminPresenter(getReportModelsAdminView(), this);
+
+		return reportModelsAdminPresenter;
+	}
+
+	@Override
+	public EditPhaseModelAdminPresenter getEditPhaseModelAdminPresenter() {
+		if (editPhaseModelAdminPresenter == null)
+			editPhaseModelAdminPresenter = new EditPhaseModelAdminPresenter(getEditPhaseModelAdminView(), this);
+
+		return editPhaseModelAdminPresenter;
+	}
+
+	@Override
+	public EditLayoutGroupAdminPresenter getEditLayoutGroupAdminPresenter() {
+		if (editLayoutGroupAdminPresenter == null)
+			editLayoutGroupAdminPresenter = new EditLayoutGroupAdminPresenter(getEditLayoutGroupAdminView(), this);
+
+		return editLayoutGroupAdminPresenter;
+	}
+
+	@Override
+	public EditFlexibleElementAdminPresenter getEditFlexibleElementAdminPresenter() {
+		if (editFlexibleElementAdminPresenter == null)
+			editFlexibleElementAdminPresenter = new EditFlexibleElementAdminPresenter(getEditFlexibleElementAdminView(),
+					this);
+
+		return editFlexibleElementAdminPresenter;
+	}
+
+	@Override
+	public AddBudgetSubFieldPresenter getAddBudgetSubFieldPresenter() {
+		if (addBudSubFieldPresenter == null)
+			addBudSubFieldPresenter = new AddBudgetSubFieldPresenter(getAddBudSubFieldView(), this);
+
+		return addBudSubFieldPresenter;
+	}
+
+	@Override
+	public ImportModelPresenter getImportModelPresenter() {
+		if (importModelPresenter == null)
+			importModelPresenter = new ImportModelPresenter(getImportModelView(), this);
+
+		return importModelPresenter;
+	}
+
+	@Override
+	public ImportationSchemeAdminPresenter getImportationShemePresenter() {
+		if (importationShemePresenter == null)
+			importationShemePresenter = new ImportationSchemeAdminPresenter(getImportationSchemeAdminView(), this);
+
+		return importationShemePresenter;
+	}
+
+	@Override
+	public AddVariableImporationSchemePresenter getAddVariableImporationSchemePresenter() {
+		if (addVariableImporationSchemePresenter == null)
+			addVariableImporationSchemePresenter = new AddVariableImporationSchemePresenter(
+					getAddVariableImporationSchemeView(), this);
+
+		return addVariableImporationSchemePresenter;
+	}
+
+	@Override
+	public AddImportationSchemeModelsAdminPresenter getAddImportationSchemeModelsAdminPresenter() {
+		if (addImportationSchemeModelsAdminPresenter == null)
+			addImportationSchemeModelsAdminPresenter = new AddImportationSchemeModelsAdminPresenter(
+					getAddImportationSchemeModelsAdminView(), this);
+
+		return addImportationSchemeModelsAdminPresenter;
+	}
+
+	@Override
+	public AddMatchingRuleImportationShemeModelsAdminPresenter getAddMatchingRuleImportationShemeModelsAdminPresenter() {
+		if (addMatchingRuleImportationShemeModelsAdminPresenter == null)
+			addMatchingRuleImportationShemeModelsAdminPresenter = new AddMatchingRuleImportationShemeModelsAdminPresenter(
+					getAddMatchingRuleImportationShemeModelsAdminView(), this);
+
+		return addMatchingRuleImportationShemeModelsAdminPresenter;
+	}
+
+	@Override
+	public FileSelectionPresenter getFileSelectionPresenter() {
+		if (fileSelectionPresenter == null)
+			fileSelectionPresenter = new FileSelectionPresenter(getFileSelectionView(), this);
+
+		return fileSelectionPresenter;
+	}
+
+	@Override
+	public UpdateDiaryAsyncDAO getUpdateDiaryAsyncDAO() {
+		
+		if (updateDiaryAsyncDAO == null)
+			  updateDiaryAsyncDAO = new UpdateDiaryAsyncDAO();
+
+		return updateDiaryAsyncDAO;
+	}
+
+	@Override
+	public TransfertManagerProvider getTransferManagerProvider() {
+
+		if (transferManagerProvider == null) {
+
+			transferManagerProvider = new TransfertManagerProvider(getDispatch(), getAuthenticationProvider(),
+					getPageManager(), getEventBus(), getFileDataAsyncDAO(), getTransfertAsyncDAO());
+		}
+
+		return transferManagerProvider;
+	}
+
+	@Override
+	public MonitoredPointAsyncDAO getMonitoredPointAsyncDAO() {
+		if (monitoredPointAsyncDAO == null)
+			monitoredPointAsyncDAO = new MonitoredPointAsyncDAO();
+
+		return monitoredPointAsyncDAO;
+	}
+
+	@Override
+	public OrgUnitAsyncDAO getOrgUnitAsyncDAO() {
+		
+		
+		if (orgUnitAsyncDAO == null)
+			orgUnitAsyncDAO = new OrgUnitAsyncDAO(getOrgUnitModelAsyncDAO(), getCountryAsyncDAO());
+
+		return orgUnitAsyncDAO;
+	}
+
+	@Override
+	public ReminderAsyncDAO getReminderAsyncDAO() {
+		if (reminderAsyncDAO == null)
+			reminderAsyncDAO = new ReminderAsyncDAO();
+
+		return reminderAsyncDAO;
+	}
+
+	@Override
+	public ApplicationView getApplicationView() {
+		if (applicationView == null)
+			applicationView = new ApplicationView();
+
+		return applicationView;
+	}
+
+	@Override
+	public MockUpView getMockUpView() {
+		
+		if (mockupView == null)
+			mockupView = new MockUpView();
+
+		return mockupView;
+	}
+
+	@Override
+	public OrganizationBannerView getOrganizationBannerView() {
+		
+		if (organizationBannerView == null)
+			organizationBannerView = new OrganizationBannerView();
+
+		return organizationBannerView;
+	}
+
+	@Override
+	public ImageProvider getImageProvider() {
+		if (imageProvider == null)
+			imageProvider = new ImageProvider(this);
+
+		return imageProvider;
+	}
+
+	@Override
+	public LogoAsyncDAO getLogoAsyncDAO() {
+		if (logoAsyncDAO == null) {
+			logoAsyncDAO = new LogoAsyncDAO();
+			logoAsyncDAO.setAuthenticationProvider(getAuthenticationProvider());
+		}
+
+		return logoAsyncDAO;
+	}
+
+	@Override
+	public AuthenticationBannerView getAuthenticationBannerView() {
+		if (authenticationBannerView == null)
+			authenticationBannerView = new AuthenticationBannerView();
+
+		return authenticationBannerView;
+	}
+
+	@Override
+	public OfflineBannerView getOfflineBannerView() {
+
+		if (offlineBannerView == null)
+			offlineBannerView = new OfflineBannerView();
+
+		return offlineBannerView;
+	}
+
+	@Override
+	public AppLoaderView getAppLoaderView() {
+		
+	if (appLoaderView == null)
+		appLoaderView = new AppLoaderView();
+
+	return appLoaderView;
+		
+	}
+
+	@Override
+	public MenuBannerView getMenuBannerView() {
+		
+		if (menuBannerView == null)
+			menuBannerView = new MenuBannerView();
+
+		return menuBannerView;
+	}
+
+	@Override
+	public MessageBannerView getMessageBannerView() {
+		if (messageBannerView == null)
+			messageBannerView = new MessageBannerView();
+
+		return messageBannerView;
+	}
+
+	@Override
+	public CreditsView getCreditsView() {
+		
+		if (creditsView == null)
+			creditsView = new CreditsView();
+
+		return creditsView;
+	}
+
+	@Override
+	public HelpView getHelpView() {
+		if (helpView == null)
+			helpView = new HelpView();
+
+		return helpView;
+	}
+
+	@Override // Not a singleton so create a new instance every time
+	public ContactsListWidget getContactsListWidget() {
+
+		return new ContactsListWidget(getContactsListView(), this);
+	}
+
+	@Override // Not a singleton so create a new instance every time
+	public ProjectsListWidget getProjectsListWidget() {
+
+		return new ProjectsListWidget(getProjectsListView(), this);
+	}
+
+	@Override
+	public ContactsListView getContactsListView() {
+		if (contactsListView == null)
+			contactsListView = new ContactsListView();
+
+		return contactsListView;
+	}
+
+	@Override
+	public ProjectsListView getProjectsListView() {
+		if (projectsListView == null)
+			projectsListView = new ProjectsListView();
+
+		return projectsListView;
+	}
+
+	@Override
+	public DashboardView getDashboardView() {
+
+		if (dashboardView == null)
+			dashboardView = new DashboardView(this);
+
+		return dashboardView;
+	}
+
+	@Override
+	public LoginView getLoginView() {
+		if (loginView == null)
+			loginView = new LoginView();
+
+		return loginView;
+	}
+
+	@Override
+	public LostPasswordView getLostPasswordView() {
+		if (lostPasswordView == null)
+			lostPasswordView = new LostPasswordView();
+
+		return lostPasswordView;
+	}
+
+	@Override
+	public ResetPasswordView getResetPasswordView() {
+		if (resetPasswordView == null)
+			resetPasswordView = new ResetPasswordView();
+
+		return resetPasswordView;
+	}
+
+	@Override
+	public ChangeOwnPasswordView getChangeOwnPasswordView() {
+	   if (changeOwnPasswordView == null)
+		changeOwnPasswordView = new ChangeOwnPasswordView();
+
+	return changeOwnPasswordView;
+	}
+
+	@Override
+	public CreateProjectView getCreateProjectView() {
+		
+		   if (createProjectView == null)
+			createProjectView = new CreateProjectView();
+
+		return createProjectView;
+	}
+
+	@Override
+	public CalendarEventView getCalendarEventView() {
+		   
+		   if (calendarEventView == null)
+			calendarEventView = new CalendarEventView();
+
+		return calendarEventView;
+	}
+
+	@Override
+	public ReportCreateView getReportCreateView() {
+		if (reportCreateView == null)
+			reportCreateView = new ReportCreateView();
+
+		return reportCreateView;
+	}
+
+	@Override
+	public AttachFileView getAttachFileView() {
+		if (attachFileView == null)
+			attachFileView = new AttachFileView();
+
+		return attachFileView;
+	}
+
+	@Override
+	public ImportationView getImportationView() {
+		if (importationView == null)
+			importationView = new ImportationView();
+
+		return importationView;
+	}
+
+	@Override
+	public ProjectDashboardView getProjectDashboardView() {
+
+		if (projectDashboardView == null) {
+
+			projectDashboardView = new ProjectDashboardView(this);
+
+		}
+
+		return projectDashboardView;
+	}
+
+	@Override
+	public ProjectLogFrameView getProjectLogFrameView() {
+
+		if (projectLogFrameView == null) {
+
+			projectLogFrameView = new ProjectLogFrameView(getProjectLogFrameGrid());
+
+		}
+
+		return projectLogFrameView;
+	}
+
+	@Override
+	public ProjectDetailsView getProjectDetailsView() {
+
+		if (projectDetailsView == null) {
+
+			projectDetailsView = new ProjectDetailsView();
+
+		}
+
+		return projectDetailsView;
+	}
+
+	@Override
+	public ProjectTeamMembersView getProjectTeamMembersView() {
+
+		if (projectTeamMembersView == null) {
+
+			projectTeamMembersView = new ProjectTeamMembersView();
+
+		}
+
+		return projectTeamMembersView;
+	}
+
+	@Override
+	public ProjectCalendarView getProjectCalendarView() {
+
+		if (projectCalendarView == null) {
+
+			projectCalendarView = new ProjectCalendarView();
+
+		}
+
+		return projectCalendarView;
+	}
+
+	@Override
+	public ProjectReportsView getProjectReportsView() {
+
+		if (projectReportsView == null) {
+
+			projectReportsView = new ProjectReportsView();
+
+		}
+
+		return projectReportsView;
+	}
+
+	@Override
+	public ReminderEditView getReminderEditView() {
+
+		if (reminderEditView == null) {
+
+			reminderEditView = new ReminderEditView();
+
+		}
+
+		return reminderEditView;
+	}
+
+	@Override
+	public ReminderHistoryView getReminderHistoryView() {
+
+		if (reminderHistoryView == null) {
+
+			reminderHistoryView = new ReminderHistoryView();
+
+		}
+
+		return reminderHistoryView;
+	}
+
+	@Override
+	public LinkedProjectView getLinkedProjectView() {
+
+		if (linkedProjectView == null) {
+
+			linkedProjectView = new LinkedProjectView();
+
+		}
+
+		return linkedProjectView;
+	}
+
+	@Override
+	public ProjectIndicatorEntriesView getProjectIndicatorEntriesView() {
+
+		if (projectIndicatorEntriesView == null) {
+
+			projectIndicatorEntriesView = new ProjectIndicatorEntriesView(getProjectPivotContainer());
+
+		}
+
+		return projectIndicatorEntriesView;
+	}
+
+	@Override
+	public ProjectIndicatorManagementView getProjectIndicatorManagementView() {
+
+		if (projectIndicatorManagementView == null) {
+
+			projectIndicatorManagementView = new ProjectIndicatorManagementView();
+
+		}
+
+		return projectIndicatorManagementView;
+	}
+
+	@Override
+	public ProjectIndicatorMapView getProjectIndicatorMapView() {
+		if (projectIndicatorMapView == null) {
+
+			projectIndicatorMapView = new ProjectIndicatorMapView(getSiteGridPanel());
+
+		}
+
+		return projectIndicatorMapView;
+	}
+
+	@Override
+	public EditIndicatorView getEditIndicatorView() {
+
+		if (editIndicatorView == null) {
+
+			editIndicatorView = new EditIndicatorView(getDispatch(), getPivotGridPanel());
+
+		}
+
+		return editIndicatorView;
+	}
+
+	@Override
+	public EditSiteView getEditSiteView() {
+
+		if (editSiteView == null) {
+
+			editSiteView = new EditSiteView();
+
+		}
+
+		return editSiteView;
+	}
+
+	@Override
+	public ExportContactsView getExportContactsView() {
+
+		if (exportContactsView == null) {
+
+			exportContactsView = new ExportContactsView();
+
+		}
+
+		return exportContactsView;
+	}
+
+	@Override
+	public ExportContactsSettingView getExportContactsSettingView() {
+
+		if (exportContactsSettingView == null) {
+
+			exportContactsSettingView = new ExportContactsSettingView();
+
+		}
+
+		return exportContactsSettingView;
+	}
+
+	@Override
+	public ExportProjectsView getExportProjectsView() {
+
+		if (exportProjectsView == null) {
+
+			exportProjectsView = new ExportProjectsView();
+
+		}
+
+		return exportProjectsView;
+	}
+
+	@Override
+	public ExportProjectsSettingView getExportProjectsSettingView() {
+
+		if (exportProjectsSettingView == null) {
+
+			exportProjectsSettingView = new ExportProjectsSettingView();
+
+		}
+
+		return exportProjectsSettingView;
+	}
+
+	@Override
+	public ProjectCoreRenameVersionView getProjectCoreRenameVersionView() {
+
+		if (projectCoreRenameVersionView == null) {
+
+			projectCoreRenameVersionView = new ProjectCoreRenameVersionView();
+
+		}
+
+		return projectCoreRenameVersionView;
+	}
+
+	@Override
+	public ProjectCoreDiffView getProjectCoreDiffView() {
+
+		if (projectCoreDiffView == null) {
+
+			projectCoreDiffView = new ProjectCoreDiffView();
+
+		}
+
+		return projectCoreDiffView;
+	}
+
+	@Override
+	public OrgUnitView getOrgUnitView() {
+
+		if (orgUnitView == null) {
+
+			orgUnitView = new OrgUnitView();
+
+		}
+
+		return orgUnitView;
+	}
+
+	@Override
+	public OrgUnitDashboardView getOrgUnitDashboardView() {
+
+		if (orgUnitDashboardView == null) {
+
+			orgUnitDashboardView = new OrgUnitDashboardView(this);
+
+		}
+
+		return orgUnitDashboardView;
+	}
+
+	@Override
+	public OrgUnitDetailsView getOrgUnitDetailsView() {
+
+		if (orgUnitDetailsView == null) {
+
+			orgUnitDetailsView = new OrgUnitDetailsView();
+
+		}
+
+		return orgUnitDetailsView;
+	}
+
+	@Override
+	public OrgUnitCalendarView getOrgUnitCalendarView() {
+
+		if (orgUnitCalendarView == null) {
+
+			orgUnitCalendarView = new OrgUnitCalendarView();
+
+		}
+
+		return orgUnitCalendarView;
+	}
+
+	@Override
+	public OrgUnitReportsView getOrgUnitReportsView() {
+
+		if (orgUnitReportsView == null) {
+
+			orgUnitReportsView = new OrgUnitReportsView();
+
+		}
+
+		return orgUnitReportsView;
+	}
+
+	@Override
+	public ContactView getContactView() {
+
+		if (contactView == null) {
+
+			contactView = new ContactView();
+
+		}
+
+		return contactView;
+	}
+
+	@Override
+	public ContactDetailsView getContactDetailsView() {
+
+		if (contactDetailsView == null) {
+
+			contactDetailsView = new ContactDetailsView();
+
+		}
+
+		return contactDetailsView;
+	}
+
+	@Override
+	public ContactRelationshipsView getContactRelationshipsView() {
+
+		if (contactRelationshipsView == null) {
+
+			contactRelationshipsView = new ContactRelationshipsView();
+
+		}
+
+		return contactRelationshipsView;
+	}
+
+	@Override
+	public ContactHistoryView getContactHistoryView() {
+
+		if (contactHistoryView == null) {
+
+			contactHistoryView = new ContactHistoryView();
+
+		}
+
+		return contactHistoryView;
+	}
+
+	@Override
+	public AdminView getAdminView() {
+
+		if (adminView == null) {
+
+			adminView = new AdminView();
+
+		}
+
+		return adminView;
+	}
+
+	@Override
+	public ParametersAdminView getParametersAdminView() {
+
+		if (parametersAdminView == null) {
+
+			parametersAdminView = new ParametersAdminView();
+
+		}
+
+		return parametersAdminView;
+	}
+
+	@Override
+	public UsersAdminView getUsersAdminView() {
+
+		if (usersAdminView == null) {
+
+			usersAdminView = new UsersAdminView();
+
+		}
+
+		return usersAdminView;
+	}
+
+	@Override
+	public PrivacyGroupEditView getPrivacyGroupEditView() {
+
+		if (privacyGroupEditView == null) {
+
+			privacyGroupEditView = new PrivacyGroupEditView();
+
+		}
+
+		return privacyGroupEditView;
+	}
+
+	@Override
+	public ProfileEditView getProfileEditView() {
+
+		if (profileEditView == null) {
+
+			profileEditView = new ProfileEditView();
+
+		}
+
+		return profileEditView;
+	}
+
+	@Override
+	public UserEditView getUserEditView() {
+
+		if (userEditView == null) {
+
+			userEditView = new UserEditView();
+
+		}
+
+		return userEditView;
+	}
+
+	@Override
+	public OrgUnitsAdminView getOrgUnitsAdminView() {
+
+		if (orgUnitsAdminView == null) {
+
+			orgUnitsAdminView = new OrgUnitsAdminView();
+
+		}
+
+		return orgUnitsAdminView;
+	}
+
+	@Override
+	public AddOrgUnitAdminView getAddOrgUnitAdminView() {
+
+		if (addOrgUnitAdminView == null) {
+
+			addOrgUnitAdminView = new AddOrgUnitAdminView();
+
+		}
+
+		return addOrgUnitAdminView;
+	}
+
+	@Override
+	public MoveOrgUnitAdminView getMoveOrgUnitAdminView() {
+
+		if (moveOrgUnitAdminView == null) {
+
+			moveOrgUnitAdminView = new MoveOrgUnitAdminView();
+
+		}
+
+		return moveOrgUnitAdminView;
+	}
+
+	@Override
+	public CategoriesAdminView getCategoriesAdminView() {
+
+		if (categoriesAdminView == null) {
+
+			categoriesAdminView = new CategoriesAdminView();
+
+		}
+
+		return categoriesAdminView;
+	}
+
+	@Override
+	public OrgUnitModelsAdminView getOrgUnitModelsAdminView() {
+
+		if (orgUnitModelsAdminView == null) {
+
+			orgUnitModelsAdminView = new OrgUnitModelsAdminView();
+
+		}
+
+		return orgUnitModelsAdminView;
+	}
+
+	@Override
+	public AddOrgUnitModelAdminView getAddOrgUnitModelAdminView() {
+
+		if (addOrgUnitModelAdminView == null) {
+
+			addOrgUnitModelAdminView = new AddOrgUnitModelAdminView();
+
+		}
+
+		return addOrgUnitModelAdminView;
+	}
+
+	@Override
+	public ProjectModelsAdminView getProjectModelsAdminView() {
+
+		if (projectModelsAdminView == null) {
+
+			projectModelsAdminView = new ProjectModelsAdminView();
+
+		}
+
+		return projectModelsAdminView;
+	}
+
+	@Override
+	public AddProjectModelAdminView getAddProjectModelAdminView() {
+
+		if (addProjectModelAdminView == null) {
+
+			addProjectModelAdminView = new AddProjectModelAdminView();
+
+		}
+
+		return addProjectModelAdminView;
+	}
+
+	@Override
+	public ContactModelsAdminView getContactModelsAdminView() {
+
+		if (contactModelsAdminView == null) {
+
+			contactModelsAdminView = new ContactModelsAdminView();
+
+		}
+
+		return contactModelsAdminView;
+	}
+
+	@Override
+	public AddContactModelAdminView getAddContactModelAdminView() {
+
+		if (addContactModelAdminView == null) {
+
+			addContactModelAdminView = new AddContactModelAdminView();
+
+		}
+
+		return addContactModelAdminView;
+	}
+
+	@Override
+	public AddImportationSchemeView getAddImportationSchemeView() {
+
+		if (addImportationSchemeView == null) {
+
+			addImportationSchemeView = new AddImportationSchemeView();
+
+		}
+
+		return addImportationSchemeView;
+	}
+
+	@Override
+	public ReportModelsAdminView getReportModelsAdminView() {
+
+		if (reportModelsAdminView == null) {
+
+			reportModelsAdminView = new ReportModelsAdminView();
+
+		}
+
+		return reportModelsAdminView;
+	}
+
+	@Override
+	public EditPhaseModelAdminView getEditPhaseModelAdminView() {
+
+		if (editPhaseModelAdminView == null) {
+
+			editPhaseModelAdminView = new EditPhaseModelAdminView();
+
+		}
+
+		return editPhaseModelAdminView;
+	}
+
+	@Override
+	public EditLayoutGroupAdminView getEditLayoutGroupAdminView() {
+
+		if (editLayoutGroupAdminView == null) {
+
+			editLayoutGroupAdminView = new EditLayoutGroupAdminView();
+
+		}
+
+		return editLayoutGroupAdminView;
+	}
+
+	@Override
+	public EditFlexibleElementAdminView getEditFlexibleElementAdminView() {
+
+		if (editFlexibleElementAdminView == null) {
+
+			editFlexibleElementAdminView = new EditFlexibleElementAdminView();
+
+		}
+
+		return editFlexibleElementAdminView;
+	}
+
+	@Override
+	public AddBudgetSubFieldView getAddBudSubFieldView() {
+
+		if (addBudSubFieldView == null) {
+
+			addBudSubFieldView = new AddBudgetSubFieldView();
+
+		}
+
+		return addBudSubFieldView;
+	}
+
+	@Override
+	public ImportModelView getImportModelView() {
+
+		if (importModelView == null) {
+
+			importModelView = new ImportModelView();
+
+		}
+
+		return importModelView;
+	}
+
+	@Override
+	public ImportationSchemeAdminView getImportationSchemeAdminView() {
+
+		if (importationSchemeAdminView == null) {
+
+			importationSchemeAdminView = new ImportationSchemeAdminView();
+
+		}
+
+		return importationSchemeAdminView;
+	}
+
+	@Override
+	public AddVariableImporationSchemeView getAddVariableImporationSchemeView() {
+
+		if (addVariableImporationSchemeView == null) {
+
+			addVariableImporationSchemeView = new AddVariableImporationSchemeView();
+
+		}
+
+		return addVariableImporationSchemeView;
+	}
+
+	@Override
+	public AddImportationSchemeModelsAdminView getAddImportationSchemeModelsAdminView() {
+
+		if (addImportationSchemeModelsAdminView == null) {
+
+			addImportationSchemeModelsAdminView = new AddImportationSchemeModelsAdminView();
+
+		}
+
+		return addImportationSchemeModelsAdminView;
+	}
+
+	@Override
+	public AddMatchingRuleImportationShemeModelsAdminView getAddMatchingRuleImportationShemeModelsAdminView() {
+
+		if (addMatchingRuleImportationShemeModelsAdminView == null) {
+
+			addMatchingRuleImportationShemeModelsAdminView = new AddMatchingRuleImportationShemeModelsAdminView();
+
+		}
+
+		return addMatchingRuleImportationShemeModelsAdminView;
+	}
+
+	@Override
+	public FileSelectionView getFileSelectionView() {
+
+		if (fileSelectionView == null) {
+
+			fileSelectionView = new FileSelectionView();
+
+		}
+
+		return fileSelectionView;
+	}
+
+	// not a singleton, so needs to return a new instance each time
+	@Override
+	public PhasesPresenter getPhasesPresenter() {
+		return new PhasesPresenter(getPhasesView(), this);
+	}
+
+	@Override
+	public PhasesView getPhasesView() {
+
+		return new PhasesView();
+	}
+
+	@Override
+	public ProjectLogFrameGrid getProjectLogFrameGrid() {
+		if (projectLogFrameGrid == null)
+			projectLogFrameGrid = new ProjectLogFrameGrid(getEventBus());
+
+		return projectLogFrameGrid;
+	}
+
+	@Override
+	public ProjectPivotContainer getProjectPivotContainer() {
+
+		if (projectPivotContainer == null)
+			projectPivotContainer = new ProjectPivotContainer(getEventBus(), getDispatch(), getPivotGridPanel(),
+					getIStateManager());
+
+		return projectPivotContainer;
+
+	}
+
+	@Override
+	public IStateManager getIStateManager() {
+		if (iStateManager == null)
+			iStateManager = new GXTStateManager();
+
+		return iStateManager;
+
+	}
+
+	@Override
+	public PivotGridPanel getPivotGridPanel() {
+
+		if (pivotGridPanel == null)
+			pivotGridPanel = new PivotGridPanel(getEventBus(), getDispatch());
+
+		return pivotGridPanel;
+	}
+
+	@Override
+	public SiteGridPanel getSiteGridPanel() {
+
+		if (siteGridPanel == null)
+			siteGridPanel = new SiteGridPanel(getEventBus(), getDispatch(), getAuthenticationProvider());
+
+		return siteGridPanel;
+
+	}
+
+	@Override
+	public ComputationTriggerManager getComputationTriggerManager() {
+
+		if (computationTriggerManager == null)
+			computationTriggerManager = new ComputationTriggerManager(getClientValueResolver());
+
+		return computationTriggerManager;
+
+	}
+
+	public ClientValueResolver getClientValueResolver() {
+
+		if (clientValueResolver == null)
+			clientValueResolver = new ClientValueResolver(getDispatch());
+
+		return clientValueResolver;
+
+	}
+
+	@Override
+	public ProjectView getProjectView() {
+		   if (projectView == null)
+			projectView = new ProjectView();
+
+		return projectView;
+	}
+
+	@Override
+	public ReportsPresenter getReportsPresenter() {
+		if (reportsPresenter == null)
+			reportsPresenter = new ReportsPresenter(getReportsView(), this);
+
+		return reportsPresenter;
+	}
+
+	@Override
+	public ReportsView getReportsView() {
+
+		if (reportsView == null)
+			reportsView = new ReportsView();
+
+		return reportsView;
+	}
+
+	@Override
+	public CalendarPresenter getCalendarPresenter() {
+		
+		
+		if (calendarPresenter == null)
+			calendarPresenter = new CalendarPresenter(getCalendarView(), this);
+
+		return calendarPresenter;
+		
+	}
+
+	@Override
+	public CalendarView getCalendarView() {
+		if (calendarView == null)
+			calendarView = new CalendarView();
+
+		return calendarView;
+	}
+
+	@Override
+	public FlexibleElementsAdminPresenter<OrgUnitModelDTO> getFlexibleElementsAdminPresenter() {
+	
+		
+		if (flexibleElementsAdminPresenter == null){
+			  flexibleElementsAdminPresenter = new FlexibleElementsAdminPresenter<OrgUnitModelDTO>(getFlexibleElementsAdminView(), this);
+		}
+			
+
+		return flexibleElementsAdminPresenter;
+	}
+
+	@Override
+	public FlexibleElementsAdminView getFlexibleElementsAdminView() {
+		
+		if (flexibleElementsAdminView == null)
+			flexibleElementsAdminView = new FlexibleElementsAdminView();
+
+		return flexibleElementsAdminView;
+	}
+
+	@Override
+	public ImportationSchemeModelsAdminView getImportationSchemeModelsAdminView() {
+		 
+		if (importationSchemeModelsAdminView == null)
+			importationSchemeModelsAdminView = new ImportationSchemeModelsAdminView();
+
+		return importationSchemeModelsAdminView;
+	}
+
+	@Override
+	public ImportationSchemeModelsAdminPresenter<OrgUnitModelDTO> getImportationSchemeModelsAdminPresenter() {
+		
+		if (importationSchemeModelsAdminPresenter == null)
+			importationSchemeModelsAdminPresenter = new ImportationSchemeModelsAdminPresenter<OrgUnitModelDTO>(getImportationSchemeModelsAdminView(), this);
+
+		return importationSchemeModelsAdminPresenter;
+	}
+
+	@Override
+	public FlexibleElementsAdminPresenter<ProjectModelDTO> getFlexibleElementsAdminPresenter2() {
+		if (flexibleElementsAdminPresenter2 == null){
+			  flexibleElementsAdminPresenter2 = new FlexibleElementsAdminPresenter<ProjectModelDTO>(getFlexibleElementsAdminView(), this);
+		}
+			
+
+		return flexibleElementsAdminPresenter2;
+	}
+
+	@Override
+	public PhaseModelsAdminPresenter getPhaseModelsAdminPresenter() {
+		if (phaseModelsAdminPresenter == null)
+			phaseModelsAdminPresenter = new PhaseModelsAdminPresenter(getPhaseModelsAdminView(), this);
+
+		return phaseModelsAdminPresenter;
+	}
+
+	@Override
+	public PhaseModelsAdminView getPhaseModelsAdminView() {
+		if (phaseModelsAdminView == null)
+			phaseModelsAdminView = new PhaseModelsAdminView();
+
+		return phaseModelsAdminView;
+	}
+
+	@Override
+	public LogFrameModelsAdminPresenter getLogFrameModelsAdminPresenter() {
+		if (logFrameModelsAdminPresenter == null)
+			logFrameModelsAdminPresenter = new LogFrameModelsAdminPresenter(getLogFrameModelsAdminView(), this);
+
+		return logFrameModelsAdminPresenter;
+	}
+
+	@Override
+	public LogFrameModelsAdminView getLogFrameModelsAdminView() {
+		if (logFrameModelsAdminView == null)
+			logFrameModelsAdminView = new LogFrameModelsAdminView();
+
+		return logFrameModelsAdminView;
+	}
+
+	@Override
+	public ImportationSchemeModelsAdminPresenter<ProjectModelDTO> getImportationSchemeModelsAdminPresenter2() {
+		if (importationSchemeModelsAdminPresenter2 == null)
+			importationSchemeModelsAdminPresenter2 = new ImportationSchemeModelsAdminPresenter<ProjectModelDTO>(getImportationSchemeModelsAdminView(), this);
+
+		return importationSchemeModelsAdminPresenter2;
+	}
+
+	@Override
+	public FlexibleElementsAdminPresenter<ContactModelDTO> getFlexibleElementsAdminPresenter3() {
+		if (flexibleElementsAdminPresenter3 == null){
+			  flexibleElementsAdminPresenter3 = new FlexibleElementsAdminPresenter<ContactModelDTO>(getFlexibleElementsAdminView(), this);
+		}
+			
+		return flexibleElementsAdminPresenter3;
+	}
+
+	@Override
+	public ProjectAsyncDAO getProjectAsyncDAO() {
+		if (projectAsyncDAO == null)
+			projectAsyncDAO = new ProjectAsyncDAO(this);
+
+		return projectAsyncDAO;
+	}
+
+	@Override
+	public ProjectModelAsyncDAO getProjectModelAsyncDAO() {
+		if (projectModelAsyncDAO == null)
+			projectModelAsyncDAO = new ProjectModelAsyncDAO(this);
+
+		return projectModelAsyncDAO;
+	}
+
+	@Override
+	public PhaseAsyncDAO getPhaseAsyncDAO() {
+		if (phaseAsyncDAO == null)
+			phaseAsyncDAO = new PhaseAsyncDAO(getPhaseModelAsyncDAO());
+
+		return phaseAsyncDAO;
+	}
+
+	@Override
+	public LogFrameAsyncDAO getLogFrameAsyncDAO() {
+		if (logFrameAsyncDAO == null)
+			logFrameAsyncDAO = new LogFrameAsyncDAO();
+
+		return logFrameAsyncDAO;
+	}
+
+	@Override
+	public ValueAsyncDAO getValueAsyncDAO() {
+		if (valueAsyncDAO == null)
+			valueAsyncDAO = new ValueAsyncDAO(getFileDataAsyncDAO());
+
+		return valueAsyncDAO;
+	}
+
+	@Override
+	public OrgUnitModelAsyncDAO getOrgUnitModelAsyncDAO() {
+		if (orgUnitModelAsyncDAO == null)
+			orgUnitModelAsyncDAO = new OrgUnitModelAsyncDAO();
+
+		return orgUnitModelAsyncDAO;
+	}
+
+	@Override
+	public CountryAsyncDAO getCountryAsyncDAO() {
+		if (countryAsyncDAO == null)
+			countryAsyncDAO = new CountryAsyncDAO();
+
+		return countryAsyncDAO;
+	}
+
+	@Override
+	public PhaseModelAsyncDAO getPhaseModelAsyncDAO() {
+		if (phaseModelAsyncDAO == null)
+			phaseModelAsyncDAO = new PhaseModelAsyncDAO();
+
+		return phaseModelAsyncDAO;
+	}
+
+	@Override
+	public ComputationAsyncDAO getComputationAsyncDAO() {
+		if (computationAsyncDAO == null)
+			computationAsyncDAO = new ComputationAsyncDAO();
+
+		return computationAsyncDAO;
+	}
+	////////////////////
+	@Override
+	public BatchCommandAsyncHandler getBatchCommandAsyncHandler() {
+		if (batchCommandAsyncHandler == null)
+		       batchCommandAsyncHandler = new BatchCommandAsyncHandler();
+
+			return batchCommandAsyncHandler;
+	}  
+	@Override
+	public CreateEntityAsyncHandler getCreateEntityAsyncHandler() {
+		if (createEntityAsyncHandler == null)
+		       createEntityAsyncHandler = new CreateEntityAsyncHandler(this);
+
+			return createEntityAsyncHandler;
+	}  
+	@Override
+	public DeleteAsyncHandler getDeleteAsyncHandler() {
+		if (deleteAsyncHandler == null)
+		       deleteAsyncHandler = new DeleteAsyncHandler(this);
+
+			return deleteAsyncHandler;
+	}  
+	@Override
+	public GetCalendarAsyncHandler getGetCalendarAsyncHandler() {
+		if (getCalendarAsyncHandler == null)
+		       getCalendarAsyncHandler = new GetCalendarAsyncHandler(this);
+
+			return getCalendarAsyncHandler;
+	}  
+	@Override
+	public GetCategoriesAsyncHandler getGetCategoriesAsyncHandler() {
+		if (getCategoriesAsyncHandler == null)
+		       getCategoriesAsyncHandler = new GetCategoriesAsyncHandler(this);
+
+			return getCategoriesAsyncHandler;
+	}  
+	@Override
+	public GetCountriesAsyncHandler getGetCountriesAsyncHandler() {
+		if (getCountriesAsyncHandler == null)
+		       getCountriesAsyncHandler = new GetCountriesAsyncHandler(getCountryAsyncDAO());
+
+			return getCountriesAsyncHandler;
+	}  
+	@Override
+	public GetCountryAsyncHandler getGetCountryAsyncHandler() {
+		if (getCountryAsyncHandler == null)
+		       getCountryAsyncHandler = new GetCountryAsyncHandler(getCountryAsyncDAO());
+
+			return getCountryAsyncHandler;
+	}  
+	@Override
+	public GetHistoryAsyncHandler getGetHistoryAsyncHandler() {
+		if (getHistoryAsyncHandler == null)
+		       getHistoryAsyncHandler = new GetHistoryAsyncHandler(getHistoryAsyncDAO());
+
+			return getHistoryAsyncHandler;
+	}  
+	@Override
+	public GetLinkedProjectsAsyncHandler getGetLinkedProjectsAsyncHandler() {
+		if (getLinkedProjectsAsyncHandler == null)
+		       getLinkedProjectsAsyncHandler = new GetLinkedProjectsAsyncHandler(getProjectAsyncDAO());
+
+			return getLinkedProjectsAsyncHandler;
+	}  
+	@Override
+	public GetMonitoredPointsAsyncHandler getGetMonitoredPointsAsyncHandler() {
+		if (getMonitoredPointsAsyncHandler == null)
+		       getMonitoredPointsAsyncHandler = new GetMonitoredPointsAsyncHandler(getMonitoredPointAsyncDAO(), getProjectAsyncDAO());
+
+			return getMonitoredPointsAsyncHandler;
+	}  
+	@Override
+	public GetOrganizationAsyncHandler getGetOrganizationAsyncHandler() {
+		if (getOrganizationAsyncHandler == null)
+		       getOrganizationAsyncHandler = new GetOrganizationAsyncHandler(getOrganizationAsyncDAO());
+
+			return getOrganizationAsyncHandler;
+	}  
+	@Override
+	public GetOrgUnitAsyncHandler getGetOrgUnitAsyncHandler() {
+		if (getOrgUnitAsyncHandler == null)
+		       getOrgUnitAsyncHandler = new GetOrgUnitAsyncHandler(getOrgUnitAsyncDAO());
+
+			return getOrgUnitAsyncHandler;
+	}  
+	@Override
+	public GetOrgUnitsAsyncHandler getGetOrgUnitsAsyncHandler() {
+		if (getOrgUnitsAsyncHandler == null)
+		       getOrgUnitsAsyncHandler = new GetOrgUnitsAsyncHandler(getOrgUnitAsyncDAO());
+
+			return getOrgUnitsAsyncHandler;
+	}  
+	@Override
+	public GetProfilesAsyncHandler getGetProfilesAsyncHandler() {
+		if (getProfilesAsyncHandler == null)
+		       getProfilesAsyncHandler = new GetProfilesAsyncHandler(getProfileAsyncDAO());
+
+			return getProfilesAsyncHandler;
+	}  
+	@Override
+	public GetProjectAsyncHandler getGetProjectAsyncHandler() {
+		if (getProjectAsyncHandler == null)
+		       getProjectAsyncHandler = new GetProjectAsyncHandler(getProjectAsyncDAO());
+
+			return getProjectAsyncHandler;
+	}  
+	@Override
+	public GetProjectsAsyncHandler getGetProjectsAsyncHandler() {
+		if (getProjectsAsyncHandler == null)
+		       getProjectsAsyncHandler = new GetProjectsAsyncHandler(getAuthenticationProvider().get(), getProjectAsyncDAO(), getOrgUnitAsyncDAO());
+
+			return getProjectsAsyncHandler;
+	}  
+	@Override
+	public GetProjectsFromIdAsyncHandler getGetProjectsFromIdAsyncHandler() {
+		if (getProjectsFromIdAsyncHandler == null)
+		       getProjectsFromIdAsyncHandler = new GetProjectsFromIdAsyncHandler(getProjectAsyncDAO());
+
+			return getProjectsFromIdAsyncHandler;
+	}  
+	@Override
+	public GetProjectDocumentsAsyncHandler getGetProjectDocumentsAsyncHandler() {
+		//here
+		if (getProjectDocumentsAsyncHandler == null)
+		       getProjectDocumentsAsyncHandler = new GetProjectDocumentsAsyncHandler(getValueAsyncDAO());
+
+			return getProjectDocumentsAsyncHandler;
+	}  
+	@Override
+	public GetProjectReportAsyncHandler getGetProjectReportAsyncHandler() {
+		if (getProjectReportAsyncHandler == null)
+		       getProjectReportAsyncHandler = new GetProjectReportAsyncHandler(getProjectReportAsyncDAO());
+
+			return getProjectReportAsyncHandler;
+	}  
+	@Override
+	public GetProjectReportsAsyncHandler getGetProjectReportsAsyncHandler() {
+		if (getProjectReportsAsyncHandler == null)
+		       getProjectReportsAsyncHandler = new GetProjectReportsAsyncHandler(getReportReferenceAsyncDAO());
+
+			return getProjectReportsAsyncHandler;
+	}  
+	@Override
+	public GetProjectTeamMembersAsyncHandler getGetProjectTeamMembersAsyncHandler() {
+		if (getProjectTeamMembersAsyncHandler == null)
+		       getProjectTeamMembersAsyncHandler = new GetProjectTeamMembersAsyncHandler(getProjectTeamMembersAsyncDAO());
+
+			return getProjectTeamMembersAsyncHandler;
+	}  
+	@Override
+	public GetRemindersAsyncHandler getGetRemindersAsyncHandler() {
+		if (getRemindersAsyncHandler == null)
+		       getRemindersAsyncHandler = new GetRemindersAsyncHandler(getReminderAsyncDAO(), getProjectAsyncDAO());
+
+			return getRemindersAsyncHandler;
+	}  
+	@Override
+	public GetSitesCountAsyncHandler getGetSitesCountAsyncHandler() {
+		if (getSitesCountAsyncHandler == null)
+		       getSitesCountAsyncHandler = new GetSitesCountAsyncHandler();
+
+			return getSitesCountAsyncHandler;
+	}  
+	@Override
+	public GetUsersByOrganizationAsyncHandler getGetUsersByOrganizationAsyncHandler() {
+		if (getUsersByOrganizationAsyncHandler == null)
+		       getUsersByOrganizationAsyncHandler = new GetUsersByOrganizationAsyncHandler(getUserAsyncDAO());
+
+			return getUsersByOrganizationAsyncHandler;
+	}  
+	@Override
+	public GetUsersByOrgUnitAsyncHandler getGetUsersByOrgUnitAsyncHandler() {
+		if (getUsersByOrgUnitAsyncHandler == null)
+		       getUsersByOrgUnitAsyncHandler = new GetUsersByOrgUnitAsyncHandler(getOrgUnitAsyncDAO(), getUserAsyncDAO());
+
+			return getUsersByOrgUnitAsyncHandler;
+	}  
+	@Override
+	public GetUserUnitsByUserAsyncHandler getGetUserUnitsByUserAsyncHandler() {
+		if (getUserUnitsByUserAsyncHandler == null)
+		       getUserUnitsByUserAsyncHandler = new GetUserUnitsByUserAsyncHandler(getUserUnitAsyncDAO());
+
+			return getUserUnitsByUserAsyncHandler;
+	}  
+	@Override
+	public GetValueAsyncHandler getGetValueAsyncHandler() {
+		if (getValueAsyncHandler == null)
+		       getValueAsyncHandler = new GetValueAsyncHandler(getValueAsyncDAO());
+
+			return getValueAsyncHandler;
+	}  
+	@Override
+	public GetValueFromLinkedProjectsAsyncHandler getGetValueFromLinkedProjectsAsyncHandler() {
+		if (getValueFromLinkedProjectsAsyncHandler == null)
+		       getValueFromLinkedProjectsAsyncHandler = new GetValueFromLinkedProjectsAsyncHandler(this);
+
+			return getValueFromLinkedProjectsAsyncHandler;
+	}  
+	@Override
+	public PrepareFileUploadAsyncHandler getPrepareFileUploadAsyncHandler() {
+		if (prepareFileUploadAsyncHandler == null)
+		       prepareFileUploadAsyncHandler = new PrepareFileUploadAsyncHandler(getValueAsyncDAO(), getUpdateDiaryAsyncDAO());
+
+			return prepareFileUploadAsyncHandler;
+	}  
+	@Override
+	public SecureNavigationAsyncHandler getSecureNavigationAsyncHandler() {
+		if (secureNavigationAsyncHandler == null)
+		       secureNavigationAsyncHandler = new SecureNavigationAsyncHandler(getAuthenticationAsyncDAO(), getPageAccessAsyncDAO());
+
+			return secureNavigationAsyncHandler;
+	}  
+	@Override
+	public UpdateEntityAsyncHandler getUpdateEntityAsyncHandler() {
+		if (updateEntityAsyncHandler == null)
+		       updateEntityAsyncHandler = new UpdateEntityAsyncHandler(this);
+
+			return updateEntityAsyncHandler;
+	}  
+	@Override
+	public UpdateLogFrameAsyncHandler getUpdateLogFrameAsyncHandler() {
+		if (updateLogFrameAsyncHandler == null)
+		       updateLogFrameAsyncHandler = new UpdateLogFrameAsyncHandler(getProjectAsyncDAO(), getUpdateDiaryAsyncDAO());
+
+			return updateLogFrameAsyncHandler;
+	}  
+	@Override
+	public UpdateMonitoredPointsAsyncHandler getUpdateMonitoredPointsAsyncHandler() {
+		if (updateMonitoredPointsAsyncHandler == null)
+		       updateMonitoredPointsAsyncHandler = new UpdateMonitoredPointsAsyncHandler(getMonitoredPointAsyncDAO(), getUpdateDiaryAsyncDAO());
+
+			return updateMonitoredPointsAsyncHandler;
+	}  
+	@Override
+	public UpdateProjectAsyncHandler getUpdateProjectAsyncHandler() {
+		if (updateProjectAsyncHandler == null)
+		       updateProjectAsyncHandler = new UpdateProjectAsyncHandler(this);
+
+			return updateProjectAsyncHandler;
+	}  
+	@Override
+	public UpdateProjectFavoriteAsyncHandler getUpdateProjectFavoriteAsyncHandler() {
+		if (updateProjectFavoriteAsyncHandler == null)
+		       updateProjectFavoriteAsyncHandler = new UpdateProjectFavoriteAsyncHandler(getProjectAsyncDAO(), getUpdateDiaryAsyncDAO());
+
+			return updateProjectFavoriteAsyncHandler;
+	}  
+	@Override
+	public UpdateProjectTeamMembersAsyncHandler getUpdateProjectTeamMembersAsyncHandler() {
+		if (updateProjectTeamMembersAsyncHandler == null)
+		       updateProjectTeamMembersAsyncHandler = new UpdateProjectTeamMembersAsyncHandler(getProjectTeamMembersAsyncDAO(), getUpdateDiaryAsyncDAO());
+
+			return updateProjectTeamMembersAsyncHandler;
+	}  
+	@Override
+	public UpdateRemindersAsyncHandler getUpdateRemindersAsyncHandler() {
+		if (updateRemindersAsyncHandler == null)
+		       updateRemindersAsyncHandler = new UpdateRemindersAsyncHandler(getReminderAsyncDAO(), getUpdateDiaryAsyncDAO());
+
+			return updateRemindersAsyncHandler;
+	}
+
+	@Override
+	public PersonalCalendarAsyncDAO getPersonalCalendarAsyncDAO() {
+		if(personalCalendarAsyncDAO == null)
+			personalCalendarAsyncDAO = new PersonalCalendarAsyncDAO();
+
+		return personalCalendarAsyncDAO;
+	}
+
+	@Override
+	public ActivityCalendarAsyncHandler getActivityCalendarAsyncHandler() {
+	
+		if (activityCalendarAsyncHandler == null)
+			activityCalendarAsyncHandler = new ActivityCalendarAsyncHandler(getProjectAsyncDAO());
+
+		return activityCalendarAsyncHandler;
+	}
+
+	@Override
+	public PersonalCalendarAsyncHandler getPersonalCalendarAsyncHandler() {
+		if (personalCalendarAsyncHandler == null)
+			personalCalendarAsyncHandler = new PersonalCalendarAsyncHandler(getPersonalCalendarAsyncDAO());
+
+		return personalCalendarAsyncHandler;
+	}
+
+	@Override
+	public MonitoredPointCalendarAsyncHandler getMonitoredPointCalendarAsyncHandler() {
+		if (monitoredPointCalendarAsyncHandler == null)
+			monitoredPointCalendarAsyncHandler = new MonitoredPointCalendarAsyncHandler(getMonitoredPointAsyncDAO());
+
+		return monitoredPointCalendarAsyncHandler;
+	}
+
+	@Override
+	public ReminderCalendarAsyncHandler getReminderCalendarAsyncHandler() {
+		if (reminderCalendarAsyncHandler == null)
+			reminderCalendarAsyncHandler = new ReminderCalendarAsyncHandler(getReminderAsyncDAO());
+
+		return reminderCalendarAsyncHandler;
+	}
+
+	@Override
+	public CategoryTypeAsyncDAO getCategoryTypeAsyncDAO() {
+		
+		if (categoryTypeAsyncDAO == null)
+			categoryTypeAsyncDAO = new CategoryTypeAsyncDAO(getCategoryElementAsyncDAO());
+
+		return categoryTypeAsyncDAO;
+	}
+
+	@Override
+	public HistoryAsyncDAO getHistoryAsyncDAO() {
+		  if (historyAsyncDAO == null)
+			historyAsyncDAO = new HistoryAsyncDAO();
+
+		return historyAsyncDAO;
+	}
+
+	@Override
+	public OrganizationAsyncDAO getOrganizationAsyncDAO() {
+		
+		if (organizationAsyncDAO == null)
+			organizationAsyncDAO = new OrganizationAsyncDAO(getOrgUnitAsyncDAO());
+
+		return organizationAsyncDAO;
+	}
+
+	@Override
+	public ProfileAsyncDAO getProfileAsyncDAO() {
+		if (profileAsyncDAO == null)
+			profileAsyncDAO = new ProfileAsyncDAO();
+
+		return profileAsyncDAO;
+	}
+
+	@Override
+	public UserAsyncDAO getUserAsyncDAO() {
+		if (userAsyncDAO == null)
+			userAsyncDAO = new UserAsyncDAO(getOrgUnitAsyncDAO());
+
+		return userAsyncDAO;
+	}
+
+	@Override
+	public UserUnitAsyncDAO getUserUnitAsyncDAO() {
+		if (userUnitAsyncDAO == null)
+			userUnitAsyncDAO = new UserUnitAsyncDAO();
+
+		return userUnitAsyncDAO;
+	}
+
+	@Override
+	public AuthenticationAsyncDAO getAuthenticationAsyncDAO() {
+		if (authenticationAsyncDAO == null)
+			authenticationAsyncDAO = new AuthenticationAsyncDAO();
+
+		return authenticationAsyncDAO;
+	}
+
+	@Override
+	public PageAccessAsyncDAO getPageAccessAsyncDAO() {
+		if (pageAccessAsyncDAO == null)
+			pageAccessAsyncDAO = new PageAccessAsyncDAO();
+
+		return pageAccessAsyncDAO;
+	}
+
+	@Override
+	public ProjectReportAsyncDAO getProjectReportAsyncDAO() {
+		if (projectReportAsyncDAO == null)
+			projectReportAsyncDAO = new ProjectReportAsyncDAO();
+
+		return projectReportAsyncDAO;
+	}
+
+	@Override
+	public ProjectTeamMembersAsyncDAO getProjectTeamMembersAsyncDAO() {
+		if (projectTeamMembersAsyncDAO == null)
+			projectTeamMembersAsyncDAO = new ProjectTeamMembersAsyncDAO();
+
+		return projectTeamMembersAsyncDAO;
+	}
+
+	@Override
+	public ReportReferenceAsyncDAO getReportReferenceAsyncDAO() {
+		if (reportReferenceAsyncDAO == null)
+			reportReferenceAsyncDAO = new ReportReferenceAsyncDAO();
+
+		return reportReferenceAsyncDAO;
+	}
+
+	@Override
+	public CategoryElementAsyncDAO getCategoryElementAsyncDAO() {
+		if (categoryElementAsyncDAO == null)
+			categoryElementAsyncDAO = new CategoryElementAsyncDAO();
+
+		return categoryElementAsyncDAO;
+	}
+
+	@Override
+	public ExceptionHandler getExceptionHandler() {
+		if (exceptionHandler == null)
+			exceptionHandler = new SecureExceptionHandler(getEventBus());
+
+		return exceptionHandler;
+	}
+ 
+	
+}

--- a/src/main/java/org/sigmah/client/Sigmah.java
+++ b/src/main/java/org/sigmah/client/Sigmah.java
@@ -50,9 +50,9 @@ public class Sigmah implements EntryPoint {
 	public static final String VERSION = "2.2-SNAPSHOT";
 
 	/**
-	 * GIN injector.
+	 * our factory for DI 
 	 */
-	private Injector injector;
+	private ClientFactory factory;
 
 	/**
 	 * {@inheritDoc}
@@ -73,14 +73,14 @@ public class Sigmah implements EntryPoint {
 		if (Log.isDebugEnabled()) {
 			Log.debug("Application > Creates GIN injector.");
 		}
-		injector = GWT.create(Injector.class);
+		factory = GWT.create(ClientFactory.class);
 		
 
 		// Set GXT theme.
 		if (Log.isDebugEnabled()) {
 			Log.debug("Application > Sets GWT default theme.");
 		}
-		GXT.setDefaultTheme(injector.getTheme(), true);
+		GXT.setDefaultTheme(factory.getTheme(), true);
 		
 
 		// Uncaught exception handler.
@@ -98,8 +98,8 @@ public class Sigmah implements EntryPoint {
 
 		clientInitializing();
 		
-		Profiler.INSTANCE.setAuthenticationProvider(injector.getAuthenticationProvider());
-		Profiler.INSTANCE.setApplicationStateManager(injector.getApplicationStateManager());
+		Profiler.INSTANCE.setAuthenticationProvider(factory.getAuthenticationProvider());
+		Profiler.INSTANCE.setApplicationStateManager(factory.getApplicationStateManager());
 
 		if (Log.isDebugEnabled()) {
 			Log.debug("Application > Client init end.");
@@ -117,103 +117,103 @@ public class Sigmah implements EntryPoint {
 		}
 
 		// Offline dispatcher
-		injector.getLocalDispatch();
-		injector.getApplicationStateManager();
+		factory.getLocalDispatch();
+		factory.getApplicationStateManager();
 		// Application presenters.
-		injector.getApplicationPresenter();
-		injector.getHomePresenter();
-		injector.getMockUpPresenter();
-		injector.getCreditsPresenter();
-		injector.getHelpPresenter();
+		factory.getApplicationPresenter();
+		factory.getHomePresenter();
+		factory.getMockUpPresenter();
+		factory.getCreditsPresenter();
+		factory.getHelpPresenter();
 		// Zones.
-		injector.getOrganizationBannerPresenter();
-		injector.getAuthenticationBannerPresenter();
-		injector.getOfflineBannerPresenter();
-		injector.getAppLoaderPresenter();
-		injector.getMenuBannerPresenter();
-		injector.getMessageBannerPresenter();
+		factory.getOrganizationBannerPresenter();
+		factory.getAuthenticationBannerPresenter();
+		factory.getOfflineBannerPresenter();
+		factory.getAppLoaderPresenter();
+		factory.getMenuBannerPresenter();
+		factory.getMessageBannerPresenter();
 		
 		// Pages.
-		injector.getLoginPresenter();
-		injector.getLostPasswordPresenter();
-		injector.getResetPasswordPresenter();
-		injector.getChangeOwnPasswordPresenter();
-		injector.getProjectPresenter();
-		injector.getProjectDashboardPresenter();
-		injector.getProjectLogFramePresenter();
-		injector.getProjectDetailsPresenter();
-		injector.getProjectTeamMembersPresenter();
-		injector.getProjectCalendarPresenter();
-		injector.getProjectReportsPresenter();
-		injector.getProjectIndicatorEntriesPresenter();
-		injector.getProjectIndicatorManagementPresenter();
-		injector.getProjectIndicatorMapPresenter();
-		injector.getEditIndicatorPresenter();
-		injector.getEditSitePresenter();
-		injector.getExportContactsPresenter();
-		injector.getExportContactsSettingPresenter();
-		injector.getExportProjectsPresenter();
-		injector.getExportProjectsSettingPresenter();
-		injector.getProjectCoreRenameVersionPresenter();
-		injector.getProjectCoreDiffPresenter();
+		factory.getLoginPresenter();
+		factory.getLostPasswordPresenter();
+		factory.getResetPasswordPresenter();
+		factory.getChangeOwnPasswordPresenter();
+		factory.getProjectPresenter();
+		factory.getProjectDashboardPresenter();
+		factory.getProjectLogFramePresenter();
+		factory.getProjectDetailsPresenter();
+		factory.getProjectTeamMembersPresenter();
+		factory.getProjectCalendarPresenter();
+		factory.getProjectReportsPresenter();
+		factory.getProjectIndicatorEntriesPresenter();
+		factory.getProjectIndicatorManagementPresenter();
+		factory.getProjectIndicatorMapPresenter();
+		factory.getEditIndicatorPresenter();
+		factory.getEditSitePresenter();
+		factory.getExportContactsPresenter();
+		factory.getExportContactsSettingPresenter();
+		factory.getExportProjectsPresenter();
+		factory.getExportProjectsSettingPresenter();
+		factory.getProjectCoreRenameVersionPresenter();
+		factory.getProjectCoreDiffPresenter();
 
-		injector.getCreateProjectPresenter();
-		injector.getReminderEditPresenter();
-		injector.getReminderHistoryPresenter();
-		injector.getLinkedProjectPresenter();
-		injector.getCalendarEventPresenter();
-		injector.getReportCreatePresenter();
-		injector.getAttachFilePresenter();
-		injector.getImportationPresenter();
+		factory.getCreateProjectPresenter();
+		factory.getReminderEditPresenter();
+		factory.getReminderHistoryPresenter();
+		factory.getLinkedProjectPresenter();
+		factory.getCalendarEventPresenter();
+		factory.getReportCreatePresenter();
+		factory.getAttachFilePresenter();
+		factory.getImportationPresenter();
 
-		injector.getAdminPresenter();
-		injector.getUsersAdminPresenter();
-		injector.getParametersAdminPresenter();
-		injector.getPrivacyGroupEditPresenter();
-		injector.getProfileEditPresenter();
-		injector.getUserEditPresenter();
-		injector.getOrgUnitsAdminPresenter();
-		injector.getAddOrgUnitAdminPresenter();
-		injector.getMoveOrgUnitAdminPresenter();
-		injector.getCategoriesAdminPresenter();
-		injector.getOrgUnitModelsAdminPresenter();
-		injector.getAddOrgUnitModelAdminPresenter();
-		injector.getProjectModelsAdminPresenter();
-		injector.getAddProjectModelAdminPresenter();
-		injector.getContactModelsAdminPresenter();
-		injector.getAddContactModelAdminPresenter();
-		injector.getReportModelsAdminPresenter();
-		injector.getEditPhaseModelAdminPresenter();
-		injector.getEditLayoutGroupAdminPresenter();
-		injector.getEditFlexibleElementAdminPresenter();
-		injector.getAddBudgetSubFieldPresenter();
-		injector.getImportModelPresenter();
-		injector.getImportationShemePresenter();
-		injector.getAddVariableImporationSchemePresenter();
-		injector.getAddImportationSchemeModelsAdminPresenter();
-		injector.getAddMatchingRuleImportationShemeModelsAdminPresenter();
+		factory.getAdminPresenter();
+		factory.getUsersAdminPresenter();
+		factory.getParametersAdminPresenter();
+		factory.getPrivacyGroupEditPresenter();
+		factory.getProfileEditPresenter();
+		factory.getUserEditPresenter();
+		factory.getOrgUnitsAdminPresenter();
+		factory.getAddOrgUnitAdminPresenter();
+		factory.getMoveOrgUnitAdminPresenter();
+		factory.getCategoriesAdminPresenter();
+		factory.getOrgUnitModelsAdminPresenter();
+		factory.getAddOrgUnitModelAdminPresenter();
+		factory.getProjectModelsAdminPresenter();
+		factory.getAddProjectModelAdminPresenter();
+		factory.getContactModelsAdminPresenter();
+		factory.getAddContactModelAdminPresenter();
+		factory.getReportModelsAdminPresenter();
+		factory.getEditPhaseModelAdminPresenter();
+		factory.getEditLayoutGroupAdminPresenter();
+		factory.getEditFlexibleElementAdminPresenter();
+		factory.getAddBudgetSubFieldPresenter();
+		factory.getImportModelPresenter();
+		factory.getImportationShemePresenter();
+		factory.getAddVariableImporationSchemePresenter();
+		factory.getAddImportationSchemeModelsAdminPresenter();
+		factory.getAddMatchingRuleImportationShemeModelsAdminPresenter();
 
-		injector.getOrgUnitPresenter();
-		injector.getOrgUnitDashboradPresenter();
-		injector.getOrgUnitCalendarPresenter();
-		injector.getOrgUnitDetailsPresenter();
-		injector.getOrgUnitReportsPresenter();
-		injector.getAddImportationSchemePresenter();
+		factory.getOrgUnitPresenter();
+		factory.getOrgUnitDashboardPresenter();
+		factory.getOrgUnitCalendarPresenter();
+		factory.getOrgUnitDetailsPresenter();
+		factory.getOrgUnitReportsPresenter();
+		factory.getAddImportationSchemePresenter();
 
-		injector.getContactPresenter();
-		injector.getContactDetailsPresenter();
-		injector.getContactRelationshipsPresenter();
-		injector.getContactHistoryPresenter();
+		factory.getContactPresenter();
+		factory.getContactDetailsPresenter();
+		factory.getContactRelationshipsPresenter();
+		factory.getContactHistoryPresenter();
 
-		injector.getFileSelectionPresenter();
+		factory.getFileSelectionPresenter();
 
 		// Propagates the network state.
-		injector.getApplicationStateManager().fireCurrentState(new Runnable() {
+		factory.getApplicationStateManager().fireCurrentState(new Runnable() {
 
 			@Override
 			public void run() {
 				// Go to the current page.
-				injector.getPageManager().fireCurrentPlace();
+				factory.getPageManager().fireCurrentPlace();
 			}
 		});
 	}

--- a/src/main/java/org/sigmah/client/cache/UserLocalCache.java
+++ b/src/main/java/org/sigmah/client/cache/UserLocalCache.java
@@ -51,28 +51,37 @@ import org.sigmah.offline.dispatch.LocalDispatchServiceAsync;
  * @author Denis Colliot (dcolliot@ideia.fr)
  * @deprecated [TO DELETE] use the command each time it's necessary.
  */
-@Singleton
+
 @Deprecated
 public class UserLocalCache {
 
 	/**
 	 * The dispatcher.
 	 */
-	@Inject
+	
 	private DispatchAsync dispatch;
 	
 	/**
 	 * Implementation of the RPC dispatch service.
 	 */
-	@Inject
+	
 	private LocalDispatchServiceAsync localDispatch;
 
 	/**
 	 * The authentication provider.
 	 */
-	@Inject
+	
 	private AuthenticationProvider authenticationProvider;
 	
+	
+	
+	public UserLocalCache(DispatchAsync dispatch, LocalDispatchServiceAsync localDispatch,
+			AuthenticationProvider authenticationProvider) {
+		this.dispatch = dispatch;
+		this.localDispatch = localDispatch;
+		this.authenticationProvider = authenticationProvider;
+	}
+
 	/**
 	 * Cache of the countries.
 	 */
@@ -91,7 +100,7 @@ public class UserLocalCache {
 	/**
 	 * Flag set to {@code true} once local client-side cache has been initialized.
 	 */
-	private boolean initialized;
+     private boolean initialized;
 
 	/**
 	 * Gets the cache of the countries.

--- a/src/main/java/org/sigmah/client/computation/ClientValueResolver.java
+++ b/src/main/java/org/sigmah/client/computation/ClientValueResolver.java
@@ -62,8 +62,12 @@ import org.sigmah.shared.util.Collections;
  */
 public class ClientValueResolver implements ValueResolver {
 
-	@Inject
+	
 	private DispatchAsync dispatch;
+	
+	public ClientValueResolver(DispatchAsync dispatch) {
+		this.dispatch = dispatch;
+	}
 
 	/**
 	 * {@inheritDoc}

--- a/src/main/java/org/sigmah/client/computation/ComputationTriggerManager.java
+++ b/src/main/java/org/sigmah/client/computation/ComputationTriggerManager.java
@@ -59,7 +59,7 @@ import org.sigmah.shared.dto.orgunit.OrgUnitDTO;
  */
 public class ComputationTriggerManager {
 
-	@Inject
+	
 	private ClientValueResolver valueResolver;
 
 	private final Map<ComputationElementDTO, Computation> computations = new HashMap<ComputationElementDTO, Computation>();
@@ -68,6 +68,11 @@ public class ComputationTriggerManager {
 	private final Map<Integer, ComputationElementDTO> elementsWithHandlers = new HashMap<Integer, ComputationElementDTO>();
 
 	private FlexibleElementContainer container;
+	
+	public ComputationTriggerManager(ClientValueResolver valueResolver){
+		this.valueResolver = valueResolver;
+		
+	}
 
 	/**
 	 * Prepare the trigger manager.

--- a/src/main/java/org/sigmah/client/dispatch/AbstractDispatchAsync.java
+++ b/src/main/java/org/sigmah/client/dispatch/AbstractDispatchAsync.java
@@ -51,10 +51,12 @@ public abstract class AbstractDispatchAsync implements DispatchAsync, OfflineEve
 	/**
 	 * The dispatch exception handler.
 	 */
-	@Inject
+	
 	private ExceptionHandler exceptionHandler;
 	
-	@Inject
+	
+	
+
 	protected EventBus eventBus;
 	
 	/**
@@ -103,6 +105,14 @@ public abstract class AbstractDispatchAsync implements DispatchAsync, OfflineEve
 	 */
 	protected <C extends Command<R>, R extends Result> void onSuccess(final C command, final R result, final AsyncCallback<R> callback) {
 		callback.onSuccess(result);
+	}
+	
+	public void setExceptionHandler(ExceptionHandler exceptionHandler) {
+		this.exceptionHandler = exceptionHandler;
+	}
+
+	public void setEventBus(EventBus eventBus) {
+		this.eventBus = eventBus;
 	}
 
 }

--- a/src/main/java/org/sigmah/client/inject/ClientModule.java
+++ b/src/main/java/org/sigmah/client/inject/ClientModule.java
@@ -1,70 +1,32 @@
 package org.sigmah.client.inject;
 
-/*
- * #%L
- * Sigmah
- * %%
- * Copyright (C) 2010 - 2016 URD
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-3.0.html>.
- * #L%
- */
-
-import org.sigmah.client.dispatch.DispatchAsync;
-import org.sigmah.client.dispatch.ExceptionHandler;
-import org.sigmah.client.event.EventBus;
-import org.sigmah.client.event.EventBusImpl;
-import org.sigmah.client.page.PageManager;
-import org.sigmah.client.security.AuthenticationProvider;
-import org.sigmah.client.security.SecureDispatchAsync;
-import org.sigmah.client.security.SecureExceptionHandler;
-import org.sigmah.client.ui.theme.SigmahTheme;
-import org.sigmah.client.ui.theme.Theme;
-
-import com.google.gwt.inject.client.AbstractGinModule;
-import com.google.inject.Singleton;
-import org.sigmah.shared.dto.pivot.content.GXTStateManager;
-import org.sigmah.shared.dto.pivot.content.IStateManager;
-
 /**
  * GIN module to bind presenters and views.
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  * @author Tom Miette (tmiette@ideia.fr)
  */
-public class ClientModule extends AbstractGinModule {
+public class ClientModule {
 
-	@Override
+	
 	protected void configure() {
 
 		// Navigation.
-		bind(EventBus.class).to(EventBusImpl.class).in(Singleton.class);
-		bind(PageManager.class).in(Singleton.class);
-
-		// Theming.
-		bind(Theme.class).to(SigmahTheme.class).in(Singleton.class);
-
-		// Presenters rely on "@ImplementedBy" annotation on their view interface.
-
-		// Dispatch & security.
-		bind(AuthenticationProvider.class).in(Singleton.class);
-		bind(ExceptionHandler.class).to(SecureExceptionHandler.class).in(Singleton.class);
-		bind(DispatchAsync.class).to(SecureDispatchAsync.class).in(Singleton.class);
-
-		// StateManager (for indicators).
-		bind(IStateManager.class).to(GXTStateManager.class);
+//		bind(EventBus.class).to(EventBusImpl.class).in(Singleton.class);
+//		bind(PageManager.class).in(Singleton.class);
+//
+//		// Theming.
+//		bind(Theme.class).to(SigmahTheme.class).in(Singleton.class);
+//
+//		// Presenters rely on "@ImplementedBy" annotation on their view interface.
+//
+//		// Dispatch & security.
+//		bind(AuthenticationProvider.class).in(Singleton.class);
+//		bind(ExceptionHandler.class).to(SecureExceptionHandler.class).in(Singleton.class);
+//		bind(DispatchAsync.class).to(SecureDispatchAsync.class).in(Singleton.class);
+//
+//		// StateManager (for indicators).
+//		bind(IStateManager.class).to(GXTStateManager.class);
 		
 	}
 

--- a/src/main/java/org/sigmah/client/inject/Injector.java
+++ b/src/main/java/org/sigmah/client/inject/Injector.java
@@ -75,9 +75,15 @@ import org.sigmah.client.ui.presenter.orgunit.OrgUnitDashboardPresenter;
 import org.sigmah.client.ui.presenter.orgunit.OrgUnitDetailsPresenter;
 import org.sigmah.client.ui.presenter.orgunit.OrgUnitPresenter;
 import org.sigmah.client.ui.presenter.orgunit.OrgUnitReportsPresenter;
+import org.sigmah.client.ui.presenter.password.ChangeOwnPasswordPresenter;
 import org.sigmah.client.ui.presenter.password.LostPasswordPresenter;
 import org.sigmah.client.ui.presenter.password.ResetPasswordPresenter;
-import org.sigmah.client.ui.presenter.project.*;
+import org.sigmah.client.ui.presenter.project.LinkedProjectPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectCalendarPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectDetailsPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectReportsPresenter;
+import org.sigmah.client.ui.presenter.project.ProjectTeamMembersPresenter;
 import org.sigmah.client.ui.presenter.project.dashboard.ProjectDashboardPresenter;
 import org.sigmah.client.ui.presenter.project.export.ExportProjectsPresenter;
 import org.sigmah.client.ui.presenter.project.export.ExportProjectsSettingPresenter;
@@ -103,15 +109,10 @@ import org.sigmah.client.ui.theme.Theme;
 import org.sigmah.offline.dao.FileDataAsyncDAO;
 import org.sigmah.offline.dao.TransfertAsyncDAO;
 import org.sigmah.offline.dispatch.LocalDispatchServiceAsync;
-import org.sigmah.offline.inject.OfflineModule;
-import org.sigmah.offline.sync.Synchronizer;
-import org.sigmah.shared.file.TransfertManager;
-
-import com.google.gwt.inject.client.GinModules;
-import com.google.gwt.inject.client.Ginjector;
-import org.sigmah.client.ui.presenter.password.ChangeOwnPasswordPresenter;
 import org.sigmah.offline.presenter.FileSelectionPresenter;
 import org.sigmah.offline.status.ApplicationStateManager;
+import org.sigmah.offline.sync.Synchronizer;
+import org.sigmah.shared.file.TransfertManager;
 
 /**
  * GIN injector.
@@ -119,11 +120,8 @@ import org.sigmah.offline.status.ApplicationStateManager;
  * @author Tom Miette (tmiette@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@GinModules(value = {
-											ClientModule.class,
-											OfflineModule.class
-})
-public interface Injector extends Ginjector {
+
+public interface Injector  {
 
 	EventBus getEventBus();
 

--- a/src/main/java/org/sigmah/client/page/PageManager.java
+++ b/src/main/java/org/sigmah/client/page/PageManager.java
@@ -85,7 +85,7 @@ public class PageManager implements ValueChangeHandler<String>, PageChangedHandl
 	 * @param eventBus
 	 *          application event bus.
 	 */
-	@Inject
+
 	public PageManager(final EventBus eventBus) {
 		this.eventBus = eventBus;
 		pages = new HashMap<String, Pair<Page, Boolean>>();

--- a/src/main/java/org/sigmah/client/security/AuthenticationProvider.java
+++ b/src/main/java/org/sigmah/client/security/AuthenticationProvider.java
@@ -32,15 +32,14 @@ import org.sigmah.shared.command.result.Authentication;
 
 import com.google.gwt.user.client.Cookies;
 import com.google.inject.Provider;
-import com.google.inject.Singleton;
 
 /**
  * Provides the {@link Authentication}.
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
-public class AuthenticationProvider implements Provider<Authentication> {
+
+public class AuthenticationProvider {
 
 	/**
 	 * <p>
@@ -60,7 +59,6 @@ public class AuthenticationProvider implements Provider<Authentication> {
 	 * 
 	 * @return The current authentication or empty authentication (never returns {@code null}).
 	 */
-	@Override
 	public Authentication get() {
 		
 		if (isAnonymous()) {

--- a/src/main/java/org/sigmah/client/security/SecureDispatchAsync.java
+++ b/src/main/java/org/sigmah/client/security/SecureDispatchAsync.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import org.sigmah.client.dispatch.AbstractDispatchAsync;
 import org.sigmah.client.dispatch.DispatchAsync;
 import org.sigmah.client.dispatch.DispatchListener;
+import org.sigmah.client.dispatch.ExceptionHandler;
 import org.sigmah.client.event.EventBus;
 import org.sigmah.client.page.PageManager;
 import org.sigmah.client.page.RequestParameter;
@@ -155,10 +156,6 @@ public class SecureDispatchAsync extends AbstractDispatchAsync {
 	 */
 	private final AuthenticationProvider authenticationProvider;
 
-	/**
-	 * The application event bus.
-	 */
-	private final EventBus eventBus;
 
 	/**
 	 * The application page manager.
@@ -194,10 +191,10 @@ public class SecureDispatchAsync extends AbstractDispatchAsync {
 	 * @param applicationStateManager
 	 *			he {@link ApplicationStateManager} implementation.
 	 */
-	@Inject
-	public SecureDispatchAsync(final AuthenticationProvider authenticationProvider, final EventBus eventBus, final PageManager pageManager, final ApplicationStateManager applicationStateManager) {
+	public SecureDispatchAsync(final AuthenticationProvider authenticationProvider, final EventBus eventBus, final PageManager pageManager, final ApplicationStateManager applicationStateManager, ExceptionHandler exceptionHandler) {
 		this.authenticationProvider = authenticationProvider;
-		this.eventBus = eventBus;
+		setEventBus(eventBus);
+		setExceptionHandler(exceptionHandler);
 		this.pageManager = pageManager;
 		this.listeners = new HashMap<Class<?>, List<DispatchListener<?, ?>>>();
 		

--- a/src/main/java/org/sigmah/client/security/SecureExceptionHandler.java
+++ b/src/main/java/org/sigmah/client/security/SecureExceptionHandler.java
@@ -50,7 +50,7 @@ public class SecureExceptionHandler implements ExceptionHandler {
 	 */
 	private final EventBus eventBus;
 
-	@Inject
+	
 	public SecureExceptionHandler(final EventBus eventBus) {
 		this.eventBus = eventBus;
 	}

--- a/src/main/java/org/sigmah/client/ui/presenter/ApplicationPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/ApplicationPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -65,13 +67,13 @@ import com.google.inject.Singleton;
  * @author Claire Yang (cyang@ideia.fr)
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class ApplicationPresenter extends AbstractPresenter<ApplicationPresenter.View> {
 
 	/**
 	 * Application view.
 	 */
-	@ImplementedBy(ApplicationView.class)
+	
 	public static interface View extends ViewInterface {
 
 		/**
@@ -132,16 +134,16 @@ public class ApplicationPresenter extends AbstractPresenter<ApplicationPresenter
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ApplicationPresenter(final View view, final Injector injector) {
+	
+	public ApplicationPresenter(final View view, final ClientFactory factory) {
 
-		super(view, injector); // Executes 'bind()' method.
+		super(view, factory); // Executes 'bind()' method.
 
-		view.initZones(injector.getOrganizationBannerPresenter().getView(), injector.getAuthenticationBannerPresenter().getView(), injector
-			.getOfflineBannerPresenter().getView(), injector.getAppLoaderPresenter().getView(), injector.getMenuBannerPresenter().getView(), injector
+		view.initZones(factory.getOrganizationBannerPresenter().getView(), factory.getAuthenticationBannerPresenter().getView(), factory
+			.getOfflineBannerPresenter().getView(), factory.getAppLoaderPresenter().getView(), factory.getMenuBannerPresenter().getView(), factory
 			.getMessageBannerPresenter().getView());
 
 	}

--- a/src/main/java/org/sigmah/client/ui/presenter/CreateProjectPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/CreateProjectPresenter.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -84,13 +85,11 @@ import com.google.inject.Singleton;
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
 public class CreateProjectPresenter extends AbstractPagePresenter<CreateProjectPresenter.View> {
 
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(CreateProjectView.class)
 	public static interface View extends ViewInterface {
 
 		void setTitle(String title);
@@ -201,9 +200,8 @@ public class CreateProjectPresenter extends AbstractPagePresenter<CreateProjectP
 	 */
 	private ProjectDTO baseProject;
 
-	@Inject
-	public CreateProjectPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public CreateProjectPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -258,7 +256,7 @@ public class CreateProjectPresenter extends AbstractPagePresenter<CreateProjectP
 
 				final ProjectModelType type;
 				if (se != null && se.getSelectedItem() != null) {
-					type = se.getSelectedItem().getVisibility(injector.getAuthenticationProvider().get().getOrganizationId());
+					type = se.getSelectedItem().getVisibility(factory.getAuthenticationProvider().get().getOrganizationId());
 				} else {
 					type = null;
 				}

--- a/src/main/java/org/sigmah/client/ui/presenter/CreditsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/CreditsPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -46,7 +48,7 @@ import com.google.inject.Singleton;
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class CreditsPresenter extends AbstractPagePresenter<CreditsPresenter.View> {
 
 	/**
@@ -87,7 +89,6 @@ public class CreditsPresenter extends AbstractPagePresenter<CreditsPresenter.Vie
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(CreditsView.class)
 	public static interface View extends ViewInterface {
 
 		HasText getVersionNameLabel();
@@ -114,9 +115,9 @@ public class CreditsPresenter extends AbstractPagePresenter<CreditsPresenter.Vie
 
 	}
 
-	@Inject
-	public CreditsPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	
+	public CreditsPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/DashboardPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/DashboardPresenter.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.i18n.I18N;
@@ -92,7 +93,7 @@ import org.sigmah.shared.dto.profile.ExecutionDTO;
  * @author Tom Miette (tmiette@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class DashboardPresenter extends AbstractPagePresenter<DashboardPresenter.View> {
 
     public static interface ReminderOrMonitoredPointHandler{
@@ -102,7 +103,7 @@ public class DashboardPresenter extends AbstractPagePresenter<DashboardPresenter
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(DashboardView.class)
+
 	public static interface View extends ViewInterface {
 
         void setReminderOrMonitoredPointHandler(ReminderOrMonitoredPointHandler handler);
@@ -203,12 +204,12 @@ public class DashboardPresenter extends AbstractPagePresenter<DashboardPresenter
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	public DashboardPresenter(final View view, final Injector injector) {
-		super(view, injector);
+
+	public DashboardPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -299,7 +300,7 @@ public class DashboardPresenter extends AbstractPagePresenter<DashboardPresenter
 		
 		// Ask the user to synchronize its favorite projects.
 		// BUGFIX #701: only showing this message if the user is online.
-		final boolean userIsOnline = injector.getApplicationStateManager().getState() == ApplicationState.ONLINE;
+		final boolean userIsOnline = factory.getApplicationStateManager().getState() == ApplicationState.ONLINE;
 		final boolean userIsDifferent = auth().getUserId() != null && !auth().getUserId().equals(lastUserId);
 		final boolean userHasSynchronized = UpdateDates.getDatabaseUpdateDate(auth()) != null;
 		if(userIsOnline && userIsDifferent && !userHasSynchronized) {
@@ -398,7 +399,7 @@ public class DashboardPresenter extends AbstractPagePresenter<DashboardPresenter
 	 * Initializes menu buttons based on authenticated user profile permissions.
 	 */
 	private void initializeMenuButtons() {
-		initializeMenuButtons(injector.getApplicationStateManager().getState());
+		initializeMenuButtons(factory.getApplicationStateManager().getState());
 	}
 	
 	private void initializeMenuButtons(ApplicationState applicationState) {

--- a/src/main/java/org/sigmah/client/ui/presenter/HelpPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/HelpPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -45,13 +47,13 @@ import com.google.inject.Singleton;
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class HelpPresenter extends AbstractPagePresenter<HelpPresenter.View> {
 
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(HelpView.class)
+
 	public static interface View extends ViewInterface {
 
 		void setHelpURL(String url);
@@ -61,9 +63,9 @@ public class HelpPresenter extends AbstractPagePresenter<HelpPresenter.View> {
 	private String url;
 	private String anchor;
 
-	@Inject
-	public HelpPresenter(final View view, final Injector injector) {
-		super(view, injector);
+
+	public HelpPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -81,7 +83,7 @@ public class HelpPresenter extends AbstractPagePresenter<HelpPresenter.View> {
 	public void onPageRequest(final PageRequest request) {
 
 		// Retrieves the anchor.
-		final Page page = injector.getPageManager().getCurrentPage(false);
+		final Page page = factory.getPageManager().getCurrentPage(false);
         //removal of all "-"/"_" because LibreOffice writer2xhtml plugin unable to 
         //      keep them in anchors of user guide html export
         anchor = page.toString().replace("-", "").replace("_", ""); 

--- a/src/main/java/org/sigmah/client/ui/presenter/LoginPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/LoginPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -61,13 +63,13 @@ import org.sigmah.client.event.UpdateEvent;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class LoginPresenter extends AbstractPagePresenter<LoginPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(LoginView.class)
+
 	public static interface View extends ViewInterface {
 
 		ListBox getLanguagesField();
@@ -103,9 +105,8 @@ public class LoginPresenter extends AbstractPagePresenter<LoginPresenter.View> {
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public LoginPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public LoginPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -200,7 +201,7 @@ public class LoginPresenter extends AbstractPagePresenter<LoginPresenter.View> {
 				if (Log.isInfoEnabled()) {
 					Log.info("Authentication proccesed successfully, reloading application.");
 				}
-				injector.getAuthenticationProvider().login(authentication);
+				factory.getAuthenticationProvider().login(authentication);
 				eventBus.fireEvent(new UpdateEvent(UpdateEvent.USER_LOGGED_IN));
 
 				if (GWT.isScript()) {

--- a/src/main/java/org/sigmah/client/ui/presenter/MockUpPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/MockUpPresenter.java
@@ -27,14 +27,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.sigmah.client.inject.Injector;
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.page.Page;
 import org.sigmah.client.page.PageRequest;
 import org.sigmah.client.page.RequestParameter;
 import org.sigmah.client.ui.notif.ConfirmCallback;
 import org.sigmah.client.ui.notif.N10N;
 import org.sigmah.client.ui.presenter.base.AbstractPagePresenter;
-import org.sigmah.client.ui.view.MockUpView;
 import org.sigmah.client.ui.view.base.ViewInterface;
 import org.sigmah.client.ui.zone.Zone;
 import org.sigmah.client.util.ClientUtils;
@@ -50,22 +49,19 @@ import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Panel;
-import com.google.inject.ImplementedBy;
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
 
 /**
  * Mock-up presenter.
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class MockUpPresenter extends AbstractPagePresenter<MockUpPresenter.View> {
 
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(MockUpView.class)
+	
 	public static interface View extends ViewInterface {
 
 		/**
@@ -96,8 +92,8 @@ public class MockUpPresenter extends AbstractPagePresenter<MockUpPresenter.View>
 	 */
 	private FilesListElementDTO filesListElementDTO;
 
-	@Inject
-	public MockUpPresenter(final View view, final Injector injector) {
+	
+	public MockUpPresenter(final View view, final ClientFactory injector) {
 		super(view, injector);
 	}
 
@@ -392,9 +388,9 @@ public class MockUpPresenter extends AbstractPagePresenter<MockUpPresenter.View>
 
 		filesListElementDTO = new FilesListElementDTO();
 		filesListElementDTO.setService(dispatch);
-		filesListElementDTO.setAuthenticationProvider(injector.getAuthenticationProvider());
+		filesListElementDTO.setAuthenticationProvider(factory.getAuthenticationProvider());
 		filesListElementDTO.setCurrentContainerDTO(projectDTO);
-		filesListElementDTO.setTransfertManager(injector.getTransfertManager());
+		filesListElementDTO.setTransfertManager(factory.getTransfertManager());
 		filesListElementDTO.setEventBus(eventBus);
 
 		filesListElementDTO.setId(2168);

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/AbstractAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/AbstractAdminPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.admin;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -54,8 +56,8 @@ public abstract class AbstractAdminPresenter<V extends AbstractAdminPresenter.Vi
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	protected AbstractAdminPresenter(final V view, final Injector injector) {
-		super(view, injector);
+	protected AbstractAdminPresenter(final V view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -63,7 +65,7 @@ public abstract class AbstractAdminPresenter<V extends AbstractAdminPresenter.Vi
 	 */
 	@Override
 	public AdminPresenter getParentPresenter() {
-		return injector.getAdminPresenter();
+		return factory.getAdminPresenter();
 	}
 
 }

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/AdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/AdminPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.admin;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -50,13 +52,11 @@ import org.sigmah.shared.dto.referential.GlobalPermissionEnum;
  * @author Maxime Lombard (mlombard@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class AdminPresenter extends AbstractPresenter<AdminPresenter.View> implements HasSubPresenter<AdminPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(AdminView.class)
 	public static interface View extends HasSubView {
 
 		/**
@@ -73,12 +73,11 @@ public class AdminPresenter extends AbstractPresenter<AdminPresenter.View> imple
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected AdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public  AdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -93,7 +92,7 @@ public class AdminPresenter extends AbstractPresenter<AdminPresenter.View> imple
 			@Override
 			public void onSubMenuClick(final SubMenuItem menuItem) {
 
-				final PageRequest currentPageRequest = injector.getPageManager().getCurrentPageRequest(false);
+				final PageRequest currentPageRequest = factory.getPageManager().getCurrentPageRequest(false);
 				eventBus.navigateRequest(menuItem.getRequest().addAllParameters(currentPageRequest.getParameters(true)));
 			}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/CategoriesAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/CategoriesAdminPresenter.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -82,13 +83,11 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class CategoriesAdminPresenter extends AbstractAdminPresenter<CategoriesAdminPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(CategoriesAdminView.class)
 	public static interface View extends AbstractAdminPresenter.View {
 
 		ListStore<CategoryTypeDTO> getCategoriesStore();
@@ -143,9 +142,8 @@ public class CategoriesAdminPresenter extends AbstractAdminPresenter<CategoriesA
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected CategoriesAdminPresenter(View view, Injector injector) {
-		super(view, injector);
+	public CategoriesAdminPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -219,7 +217,7 @@ public class CategoriesAdminPresenter extends AbstractAdminPresenter<CategoriesA
 			public void onClickHandler(CategoryTypeDTO categoryTypeDTO) {
 
 				final ServletUrlBuilder urlBuilder =
-						new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_MODEL_CATEGORY);
+						new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_MODEL_CATEGORY);
 
 				urlBuilder.addParameter(RequestParameter.ID, categoryTypeDTO.getId());
 

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/ParametersAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/ParametersAdminPresenter.java
@@ -45,6 +45,7 @@ import com.extjs.gxt.ui.client.widget.form.TextField;
 
 import java.util.Set;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.inject.Injector;
@@ -86,13 +87,11 @@ import com.allen_sauer.gwt.log.client.Log;
  * @author Maxime Lombard (mlombard@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ParametersAdminPresenter extends AbstractAdminPresenter<ParametersAdminPresenter.View> implements HasForm {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ParametersAdminView.class)
 	public static interface View extends AbstractAdminPresenter.View {
 
 		// --
@@ -190,11 +189,10 @@ public class ParametersAdminPresenter extends AbstractAdminPresenter<ParametersA
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected ParametersAdminPresenter(View view, Injector injector, ImageProvider imageProvider) {
-		super(view, injector);
+	public ParametersAdminPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 
-		this.imageProvider = imageProvider;
+		this.imageProvider = factory.getImageProvider();
 	}
 
 	/**
@@ -258,7 +256,7 @@ public class ParametersAdminPresenter extends AbstractAdminPresenter<ParametersA
 				if (ClientUtils.isNotBlank(logoFileName)) {
 					// Submit logo file upload form.
 					final ServletUrlBuilder urlBuilder =
-							new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.FILE, ServletMethod.UPLOAD_ORGANIZATION_LOGO);
+							new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.FILE, ServletMethod.UPLOAD_ORGANIZATION_LOGO);
 					urlBuilder.addParameter(RequestParameter.ID, auth().getOrganizationId());
 
 					view.getGeneralParametersForm().setAction(urlBuilder.toString());
@@ -440,7 +438,7 @@ public class ParametersAdminPresenter extends AbstractAdminPresenter<ParametersA
 					public void onClick(final ClickEvent event) {
 
 						final ServletUrlBuilder builder =
-								new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.FILE, ServletMethod.DOWNLOAD_ARCHIVE);
+								new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.FILE, ServletMethod.DOWNLOAD_ARCHIVE);
 						builder.addParameter(RequestParameter.ID, result.getArchiveFileName());
 
 						ClientUtils.launchDownload(builder.toString());

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/ReportModelsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/ReportModelsAdminPresenter.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -82,13 +83,11 @@ import com.google.inject.Singleton;
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class ReportModelsAdminPresenter extends AbstractAdminPresenter<ReportModelsAdminPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ReportModelsAdminView.class)
 	public static interface View extends AbstractAdminPresenter.View {
 
 		LoadingMask getReportModelsLoadingMonitor();
@@ -153,9 +152,8 @@ public class ReportModelsAdminPresenter extends AbstractAdminPresenter<ReportMod
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected ReportModelsAdminPresenter(View view, Injector injector) {
-		super(view, injector);
+	public ReportModelsAdminPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -252,7 +250,7 @@ public class ReportModelsAdminPresenter extends AbstractAdminPresenter<ReportMod
 			@Override
 			public void onClickHandler(ReportModelDTO reportModelDTO) {
 				final ServletUrlBuilder urlBuilder =
-						new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_MODEL_REPORT);
+						new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_MODEL_REPORT);
 
 				urlBuilder.addParameter(RequestParameter.ID, reportModelDTO.getId());
 

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/importation/AddImportationSchemePresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/importation/AddImportationSchemePresenter.java
@@ -26,6 +26,7 @@ package org.sigmah.client.ui.presenter.admin.importation;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -61,7 +62,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class AddImportationSchemePresenter extends AbstractPagePresenter<AddImportationSchemePresenter.View> {
 
 	public static final String VALUE = "type";
@@ -74,7 +74,6 @@ public class AddImportationSchemePresenter extends AbstractPagePresenter<AddImpo
 	 * The view interface managed by this presenter.
 	 */
 
-	@ImplementedBy(AddImportationSchemeView.class)
 	public static interface View extends ViewInterface {
 
 		TextField<String> getNameField();
@@ -107,9 +106,8 @@ public class AddImportationSchemePresenter extends AbstractPagePresenter<AddImpo
 
 	}
 
-	@Inject
-	protected AddImportationSchemePresenter(View view, Injector injector) {
-		super(view, injector);
+	public AddImportationSchemePresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/importation/AddVariableImporationSchemePresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/importation/AddVariableImporationSchemePresenter.java
@@ -26,6 +26,7 @@ package org.sigmah.client.ui.presenter.admin.importation;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -60,7 +61,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class AddVariableImporationSchemePresenter extends AbstractPagePresenter<AddVariableImporationSchemePresenter.View> {
 
 	private ImportationSchemeDTO currentImportationSheme;
@@ -71,7 +71,6 @@ public class AddVariableImporationSchemePresenter extends AbstractPagePresenter<
 	 * The view interface managed by this presenter.
 	 */
 
-	@ImplementedBy(AddVariableImporationSchemeView.class)
 	public static interface View extends ViewInterface {
 
 		TextField<String> getNameField();
@@ -86,9 +85,8 @@ public class AddVariableImporationSchemePresenter extends AbstractPagePresenter<
 
 	}
 
-	@Inject
-	public AddVariableImporationSchemePresenter(View view, Injector injector) {
-		super(view, injector);
+	public AddVariableImporationSchemePresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/importation/ImportationSchemeAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/importation/ImportationSchemeAdminPresenter.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -77,7 +78,6 @@ import org.sigmah.shared.command.result.VoidResult;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ImportationSchemeAdminPresenter extends AbstractAdminPresenter<ImportationSchemeAdminPresenter.View> {
 
 	/**
@@ -88,7 +88,6 @@ public class ImportationSchemeAdminPresenter extends AbstractAdminPresenter<Impo
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ImportationSchemeAdminView.class)
 	public static interface View extends AbstractAdminPresenter.View {
 
 		void setImportationSchemePresenterHandler(ImportationSchemePresenterHandler importationSchemePresenterHandler);
@@ -167,9 +166,8 @@ public class ImportationSchemeAdminPresenter extends AbstractAdminPresenter<Impo
 
 	}
 
-	@Inject
-	protected ImportationSchemeAdminPresenter(View view, Injector injector) {
-		super(view, injector);
+	public ImportationSchemeAdminPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/AddBudgetSubFieldPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/AddBudgetSubFieldPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.admin.models;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -46,12 +48,11 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class AddBudgetSubFieldPresenter extends AbstractPagePresenter<AddBudgetSubFieldPresenter.View> {
 
 	private BudgetSubFieldDTO currentBudgetSubField;
 
-	@ImplementedBy(AddBudgetSubFieldView.class)
+
 	public static interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -62,9 +63,8 @@ public class AddBudgetSubFieldPresenter extends AbstractPagePresenter<AddBudgetS
 
 	}
 
-	@Inject
-	public AddBudgetSubFieldPresenter(View view, Injector injector) {
-		super(view, injector);
+	public AddBudgetSubFieldPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/EditFlexibleElementAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/EditFlexibleElementAdminPresenter.java
@@ -1,5 +1,86 @@
 package org.sigmah.client.ui.presenter.admin.models;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.sigmah.client.ClientFactory;
+import org.sigmah.client.dispatch.CommandResultHandler;
+import org.sigmah.client.dispatch.monitor.LoadingMask;
+import org.sigmah.client.event.UpdateEvent;
+import org.sigmah.client.event.handler.UpdateHandler;
+import org.sigmah.client.i18n.I18N;
+import org.sigmah.client.inject.Injector;
+import org.sigmah.client.page.Page;
+import org.sigmah.client.page.PageRequest;
+import org.sigmah.client.page.RequestParameter;
+import org.sigmah.client.ui.notif.N10N;
+import org.sigmah.client.ui.presenter.base.AbstractPagePresenter;
+import org.sigmah.client.ui.presenter.base.HasForm;
+import org.sigmah.client.ui.res.icon.IconImageBundle;
+import org.sigmah.client.ui.view.base.ViewPopupInterface;
+import org.sigmah.client.ui.widget.HasGrid;
+import org.sigmah.client.ui.widget.button.Button;
+import org.sigmah.client.ui.widget.form.FormPanel;
+import org.sigmah.client.ui.widget.form.ListComboBox;
+import org.sigmah.client.util.AdminUtil;
+import org.sigmah.client.util.ClientUtils;
+import org.sigmah.client.util.EnumModel;
+import org.sigmah.client.util.TypeModel;
+import org.sigmah.shared.command.CreateEntity;
+import org.sigmah.shared.command.GetCategories;
+import org.sigmah.shared.command.GetContactModels;
+import org.sigmah.shared.command.GetPrivacyGroups;
+import org.sigmah.shared.command.GetReportModels;
+import org.sigmah.shared.command.UpdateEntity;
+import org.sigmah.shared.command.result.CreateResult;
+import org.sigmah.shared.command.result.ListResult;
+import org.sigmah.shared.command.result.VoidResult;
+import org.sigmah.shared.computation.Computation;
+import org.sigmah.shared.computation.Computations;
+import org.sigmah.shared.computation.dependency.SingleDependency;
+import org.sigmah.shared.computation.value.ComputedValues;
+import org.sigmah.shared.dto.ContactModelDTO;
+import org.sigmah.shared.dto.IsModel;
+import org.sigmah.shared.dto.OrgUnitBannerDTO;
+import org.sigmah.shared.dto.ProjectBannerDTO;
+import org.sigmah.shared.dto.base.AbstractModelDataEntityDTO;
+import org.sigmah.shared.dto.category.CategoryTypeDTO;
+import org.sigmah.shared.dto.element.BudgetElementDTO;
+import org.sigmah.shared.dto.element.BudgetRatioElementDTO;
+import org.sigmah.shared.dto.element.BudgetSubFieldDTO;
+import org.sigmah.shared.dto.element.ComputationElementDTO;
+import org.sigmah.shared.dto.element.ContactListElementDTO;
+import org.sigmah.shared.dto.element.FilesListElementDTO;
+import org.sigmah.shared.dto.element.FlexibleElementDTO;
+import org.sigmah.shared.dto.element.QuestionChoiceElementDTO;
+import org.sigmah.shared.dto.element.QuestionElementDTO;
+import org.sigmah.shared.dto.element.ReportElementDTO;
+import org.sigmah.shared.dto.element.ReportListElementDTO;
+import org.sigmah.shared.dto.element.TextAreaElementDTO;
+import org.sigmah.shared.dto.layout.LayoutConstraintDTO;
+import org.sigmah.shared.dto.layout.LayoutDTO;
+import org.sigmah.shared.dto.layout.LayoutGroupDTO;
+import org.sigmah.shared.dto.profile.PrivacyGroupDTO;
+import org.sigmah.shared.dto.referential.BudgetSubFieldType;
+import org.sigmah.shared.dto.referential.ContactModelType;
+import org.sigmah.shared.dto.referential.DefaultFlexibleElementType;
+import org.sigmah.shared.dto.referential.ElementTypeEnum;
+import org.sigmah.shared.dto.referential.LogicalElementType;
+import org.sigmah.shared.dto.referential.LogicalElementTypes;
+import org.sigmah.shared.dto.referential.TextAreaType;
+import org.sigmah.shared.dto.report.ReportModelDTO;
+import org.sigmah.shared.util.Collections;
+
 /*
  * #%L
  * Sigmah
@@ -49,102 +130,18 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.FlexTable;
-import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
-import org.sigmah.client.dispatch.CommandResultHandler;
-import org.sigmah.client.dispatch.monitor.LoadingMask;
-import org.sigmah.client.event.UpdateEvent;
-import org.sigmah.client.event.handler.UpdateHandler;
-import org.sigmah.client.i18n.I18N;
-import org.sigmah.client.inject.Injector;
-import org.sigmah.client.page.Page;
-import org.sigmah.client.page.PageRequest;
-import org.sigmah.client.page.RequestParameter;
-import org.sigmah.client.ui.notif.N10N;
-import org.sigmah.client.ui.presenter.base.AbstractPagePresenter;
-import org.sigmah.client.ui.presenter.base.HasForm;
-import org.sigmah.client.ui.res.icon.IconImageBundle;
-import org.sigmah.client.ui.view.admin.models.EditFlexibleElementAdminView;
-import org.sigmah.client.ui.view.base.ViewPopupInterface;
-import org.sigmah.client.ui.widget.HasGrid;
-import org.sigmah.client.ui.widget.button.Button;
-import org.sigmah.client.ui.widget.form.FormPanel;
-import org.sigmah.client.ui.widget.form.ListComboBox;
-import org.sigmah.client.util.AdminUtil;
-import org.sigmah.client.util.ClientUtils;
-import org.sigmah.client.util.EnumModel;
-import org.sigmah.client.util.TypeModel;
-import org.sigmah.shared.command.CreateEntity;
-import org.sigmah.shared.command.GetCategories;
-import org.sigmah.shared.command.GetContactModels;
-import org.sigmah.shared.command.GetPrivacyGroups;
-import org.sigmah.shared.command.GetReportModels;
-import org.sigmah.shared.command.UpdateEntity;
-import org.sigmah.shared.command.result.CreateResult;
-import org.sigmah.shared.command.result.ListResult;
-import org.sigmah.shared.command.result.VoidResult;
-import org.sigmah.shared.computation.Computation;
-import org.sigmah.shared.computation.Computations;
-import org.sigmah.shared.computation.value.ComputedValues;
-import org.sigmah.shared.dto.ContactModelDTO;
-import org.sigmah.shared.dto.IsModel;
-import org.sigmah.shared.dto.OrgUnitBannerDTO;
-import org.sigmah.shared.dto.ProjectBannerDTO;
-import org.sigmah.shared.dto.base.AbstractModelDataEntityDTO;
-import org.sigmah.shared.dto.category.CategoryTypeDTO;
-import org.sigmah.shared.dto.element.BudgetElementDTO;
-import org.sigmah.shared.dto.element.BudgetRatioElementDTO;
-import org.sigmah.shared.dto.element.BudgetSubFieldDTO;
-import org.sigmah.shared.dto.element.ComputationElementDTO;
-import org.sigmah.shared.dto.element.ContactListElementDTO;
-import org.sigmah.shared.dto.element.FilesListElementDTO;
-import org.sigmah.shared.dto.element.FlexibleElementDTO;
-import org.sigmah.shared.dto.element.QuestionChoiceElementDTO;
-import org.sigmah.shared.dto.element.QuestionElementDTO;
-import org.sigmah.shared.dto.element.ReportElementDTO;
-import org.sigmah.shared.dto.element.ReportListElementDTO;
-import org.sigmah.shared.dto.element.TextAreaElementDTO;
-import org.sigmah.shared.dto.layout.LayoutConstraintDTO;
-import org.sigmah.shared.dto.layout.LayoutDTO;
-import org.sigmah.shared.dto.layout.LayoutGroupDTO;
-import org.sigmah.shared.dto.profile.PrivacyGroupDTO;
-import org.sigmah.shared.dto.referential.BudgetSubFieldType;
-import org.sigmah.shared.dto.referential.ContactModelType;
-import org.sigmah.shared.dto.referential.DefaultFlexibleElementType;
-import org.sigmah.shared.dto.referential.ElementTypeEnum;
-import org.sigmah.shared.dto.referential.LogicalElementType;
-import org.sigmah.shared.dto.referential.LogicalElementTypes;
-import org.sigmah.shared.dto.referential.TextAreaType;
-import org.sigmah.shared.dto.report.ReportModelDTO;
-import org.sigmah.shared.util.Collections;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeSet;
-import org.sigmah.shared.computation.dependency.SingleDependency;
 
 /**
  * Presenter in charge of creating/editing a flexible element.
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class EditFlexibleElementAdminPresenter extends AbstractPagePresenter<EditFlexibleElementAdminPresenter.View> implements HasForm {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(EditFlexibleElementAdminView.class)
 	public static interface View extends ViewPopupInterface, HasGrid<FlexibleElementDTO> {
 
 		// --
@@ -356,12 +353,11 @@ public class EditFlexibleElementAdminPresenter extends AbstractPagePresenter<Edi
 	 * 
 	 * @param view
 	 *          The view managed by the presenter.
-	 * @param injector
+	 * @param factory
 	 *          The application injector.
 	 */
-	@Inject
-	protected EditFlexibleElementAdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public EditFlexibleElementAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/EditLayoutGroupAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/EditLayoutGroupAdminPresenter.java
@@ -26,6 +26,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.extjs.gxt.ui.client.widget.form.CheckBox;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -77,13 +79,11 @@ import org.sigmah.shared.dto.referential.ElementTypeEnum;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class EditLayoutGroupAdminPresenter extends AbstractPagePresenter<EditLayoutGroupAdminPresenter.View> implements HasForm {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(EditLayoutGroupAdminView.class)
 	public static interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -114,9 +114,8 @@ public class EditLayoutGroupAdminPresenter extends AbstractPagePresenter<EditLay
 	 * @param injector
 	 *          The application injector.
 	 */
-	@Inject
-	protected EditLayoutGroupAdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public EditLayoutGroupAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/FlexibleElementsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/FlexibleElementsAdminPresenter.java
@@ -26,6 +26,7 @@ package org.sigmah.client.ui.presenter.admin.models;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.event.handler.UpdateHandler;
@@ -80,7 +81,6 @@ public class FlexibleElementsAdminPresenter<E extends IsModel> extends AbstractP
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(FlexibleElementsAdminView.class)
 	public static interface View extends ViewInterface, HasGrid<FlexibleElementDTO> {
 
 		void setModelEditable(final boolean editable);
@@ -116,12 +116,11 @@ public class FlexibleElementsAdminPresenter<E extends IsModel> extends AbstractP
 	 * 
 	 * @param view
 	 *          The view managed by this presenter.
-	 * @param injector
+	 * @param factory
 	 *          The application injector.
 	 */
-	@Inject
-	public FlexibleElementsAdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public FlexibleElementsAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/base/AbstractModelsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/base/AbstractModelsAdminPresenter.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.event.handler.UpdateHandler;
@@ -232,9 +233,8 @@ public abstract class AbstractModelsAdminPresenter<E extends IsModel, V extends 
 	 *          The tab presenters.
 	 */
 	@SafeVarargs
-	@Inject
-	protected AbstractModelsAdminPresenter(final V view, final Injector injector, final IsModelTabPresenter<E, ?>... tabPresenters) {
-		super(view, injector);
+	public AbstractModelsAdminPresenter(final V view, final ClientFactory factory, final IsModelTabPresenter<E, ?>... tabPresenters) {
+		super(view, factory);
 		this.tabPresenters = tabPresenters;
 	}
 
@@ -846,11 +846,11 @@ public abstract class AbstractModelsAdminPresenter<E extends IsModel, V extends 
 	private void onExportAction(final E model) {
 		final ServletUrlBuilder urlBuilder;
 		if (model instanceof ProjectModelDTO) {
-			urlBuilder = new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_MODEL_PROJECT);
+			urlBuilder = new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_MODEL_PROJECT);
 		} else if (model instanceof OrgUnitModelDTO) {
-			urlBuilder = new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_MODEL_ORGUNIT);
+			urlBuilder = new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_MODEL_ORGUNIT);
 		} else if (model instanceof ContactModelDTO) {
-			urlBuilder = new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_MODEL_CONTACT);
+			urlBuilder = new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_MODEL_CONTACT);
 		} else {
 			throw new IllegalStateException("Model type not supported : " + model.getClass());
 		}

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/contact/AddContactModelAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/contact/AddContactModelAdminPresenter.java
@@ -32,6 +32,7 @@ import com.extjs.gxt.ui.client.widget.form.Field;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -52,10 +53,10 @@ import org.sigmah.shared.dto.ContactModelDTO;
 import org.sigmah.shared.dto.referential.ContactModelType;
 import org.sigmah.shared.dto.referential.ProjectModelStatus;
 
-@Singleton
+
 public class AddContactModelAdminPresenter extends AbstractPagePresenter<AddContactModelAdminPresenter.View> implements HasForm {
 
-	@ImplementedBy(AddContactModelAdminView.class)
+
 	public interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -68,9 +69,9 @@ public class AddContactModelAdminPresenter extends AbstractPagePresenter<AddCont
 
 	}
 
-	@Inject
-	protected AddContactModelAdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+
+	public AddContactModelAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/contact/ContactModelsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/contact/ContactModelsAdminPresenter.java
@@ -30,6 +30,7 @@ import com.extjs.gxt.ui.client.widget.form.Field;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -55,7 +56,7 @@ import org.sigmah.shared.dto.referential.ContactModelType;
 import org.sigmah.shared.dto.referential.ProjectModelStatus;
 
 public class ContactModelsAdminPresenter extends AbstractModelsAdminPresenter<ContactModelDTO, ContactModelsAdminPresenter.View> {
-  @ImplementedBy(ContactModelsAdminView.class)
+  
   public interface View extends AbstractModelsAdminPresenter.View<ContactModelDTO> {
 
     Field<String> getNameField();
@@ -64,9 +65,8 @@ public class ContactModelsAdminPresenter extends AbstractModelsAdminPresenter<Co
 
   }
 
-  @Inject
-  protected ContactModelsAdminPresenter(ContactModelsAdminPresenter.View view, Injector injector, Provider<FlexibleElementsAdminPresenter<ContactModelDTO>> flexibleElementsProvider) {
-    super(view, injector, flexibleElementsProvider.get());
+  public ContactModelsAdminPresenter(ContactModelsAdminPresenter.View view, ClientFactory factory) {
+    super(view, factory, factory.getFlexibleElementsAdminPresenter3());
   }
 
   @Override

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/importer/AddImportationSchemeModelsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/importer/AddImportationSchemeModelsAdminPresenter.java
@@ -26,6 +26,7 @@ package org.sigmah.client.ui.presenter.admin.models.importer;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -65,7 +66,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
 
-@Singleton
 public class AddImportationSchemeModelsAdminPresenter extends AbstractPagePresenter<AddImportationSchemeModelsAdminPresenter.View> {
 
 	private EntityDTO<Integer> model;
@@ -73,7 +73,6 @@ public class AddImportationSchemeModelsAdminPresenter extends AbstractPagePresen
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(AddImportationSchemeModelsAdminView.class)
 	public static interface View extends ViewPopupInterface {
 
 		ComboBox<ImportationSchemeDTO> getSchemasCombo();
@@ -88,9 +87,8 @@ public class AddImportationSchemeModelsAdminPresenter extends AbstractPagePresen
 
 	}
 
-	@Inject
-	protected AddImportationSchemeModelsAdminPresenter(View view, Injector injector) {
-		super(view, injector);
+	public AddImportationSchemeModelsAdminPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/importer/AddMatchingRuleImportationShemeModelsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/importer/AddMatchingRuleImportationShemeModelsAdminPresenter.java
@@ -55,6 +55,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.ArrayList;
 import java.util.HashMap;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.ui.notif.N10N;
@@ -76,7 +78,6 @@ import org.sigmah.shared.dto.referential.BudgetSubFieldType;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class AddMatchingRuleImportationShemeModelsAdminPresenter extends AbstractPagePresenter<AddMatchingRuleImportationShemeModelsAdminPresenter.View> {
 
 	private EntityDTO<Integer> currentModel;
@@ -85,8 +86,6 @@ public class AddMatchingRuleImportationShemeModelsAdminPresenter extends Abstrac
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-
-	@ImplementedBy(AddMatchingRuleImportationShemeModelsAdminView.class)
 	public static interface View extends ViewPopupInterface {
 
 		ComboBox<VariableDTO> getVariablesCombo();
@@ -112,9 +111,8 @@ public class AddMatchingRuleImportationShemeModelsAdminPresenter extends Abstrac
 		boolean isValid();
 	}
 
-	@Inject
-	protected AddMatchingRuleImportationShemeModelsAdminPresenter(View view, Injector injector) {
-		super(view, injector);
+	public AddMatchingRuleImportationShemeModelsAdminPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/importer/ImportModelPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/importer/ImportModelPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.admin.models.importer;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -51,14 +53,12 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)v2.0
  */
-@Singleton
 public class ImportModelPresenter extends AbstractPagePresenter<ImportModelPresenter.View> {
 
 	private ServletMethod method;
 	private String message;
 	private String type;
 
-	@ImplementedBy(ImportModelView.class)
 	public static interface View extends ViewPopupInterface {
 
 		Button getImportButton();
@@ -75,9 +75,8 @@ public class ImportModelPresenter extends AbstractPagePresenter<ImportModelPrese
 
 	}
 
-	@Inject
-	protected ImportModelPresenter(View view, Injector injector) {
-		super(view, injector);
+	public ImportModelPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override
@@ -255,7 +254,7 @@ public class ImportModelPresenter extends AbstractPagePresenter<ImportModelPrese
 
 		if (view.getForm().isValid()) {
 
-			ServletUrlBuilder url = new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.IMPORT, method);
+			ServletUrlBuilder url = new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.IMPORT, method);
 			view.getForm().setAction(url.toString());
 			view.getForm().submit();
 

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/importer/ImportationSchemeModelsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/importer/ImportationSchemeModelsAdminPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.admin.models.importer;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -78,7 +80,6 @@ implements IsModelTabPresenter<E, ImportationSchemeModelsAdminPresenter.View> {
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ImportationSchemeModelsAdminView.class)
 	public static interface View extends ViewInterface {
 
 		ListStore<ImportationSchemeModelDTO> getImportationSchemeModelsStore();
@@ -119,9 +120,8 @@ implements IsModelTabPresenter<E, ImportationSchemeModelsAdminPresenter.View> {
 
 	}
 
-	@Inject
-	protected ImportationSchemeModelsAdminPresenter(View view, Injector injector) {
-		super(view, injector);
+	public ImportationSchemeModelsAdminPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/orgunit/AddOrgUnitModelAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/orgunit/AddOrgUnitModelAdminPresenter.java
@@ -25,16 +25,15 @@ package org.sigmah.client.ui.presenter.admin.models.orgunit;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
-import org.sigmah.client.inject.Injector;
 import org.sigmah.client.page.Page;
 import org.sigmah.client.page.PageRequest;
 import org.sigmah.client.ui.notif.N10N;
 import org.sigmah.client.ui.presenter.base.AbstractPagePresenter;
 import org.sigmah.client.ui.presenter.base.HasForm;
-import org.sigmah.client.ui.view.admin.models.orgunit.AddOrgUnitModelAdminView;
 import org.sigmah.client.ui.view.base.ViewPopupInterface;
 import org.sigmah.client.ui.widget.button.Button;
 import org.sigmah.client.ui.widget.form.FormPanel;
@@ -47,9 +46,6 @@ import org.sigmah.shared.dto.referential.ProjectModelStatus;
 import com.extjs.gxt.ui.client.event.ButtonEvent;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.widget.form.Field;
-import com.google.inject.ImplementedBy;
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
 
 /**
  * Presenter in charge of adding a new OrgUnit model.
@@ -57,13 +53,11 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class AddOrgUnitModelAdminPresenter extends AbstractPagePresenter<AddOrgUnitModelAdminPresenter.View> implements HasForm {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(AddOrgUnitModelAdminView.class)
 	public static interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -88,9 +82,8 @@ public class AddOrgUnitModelAdminPresenter extends AbstractPagePresenter<AddOrgU
 	 * @param injector
 	 *          The application injector.
 	 */
-	@Inject
-	protected AddOrgUnitModelAdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public AddOrgUnitModelAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/orgunit/OrgUnitModelsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/orgunit/OrgUnitModelsAdminPresenter.java
@@ -26,6 +26,7 @@ package org.sigmah.client.ui.presenter.admin.models.orgunit;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -63,13 +64,11 @@ import com.google.inject.Singleton;
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  */
-@Singleton
 public class OrgUnitModelsAdminPresenter extends AbstractModelsAdminPresenter<OrgUnitModelDTO, OrgUnitModelsAdminPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(OrgUnitModelsAdminView.class)
 	public static interface View extends AbstractModelsAdminPresenter.View<OrgUnitModelDTO> {
 
 		Field<String> getNameField();
@@ -92,9 +91,8 @@ public class OrgUnitModelsAdminPresenter extends AbstractModelsAdminPresenter<Or
 	 * @param flexibleElementsProvider
 	 *          The {@link FlexibleElementsAdminPresenter} provider.
 	 */
-	@Inject
-	protected OrgUnitModelsAdminPresenter(final View view, final Injector injector, final Provider<FlexibleElementsAdminPresenter<OrgUnitModelDTO>> flexibleElementsProvider, final Provider<ImportationSchemeModelsAdminPresenter<OrgUnitModelDTO>> importationSchemeModelsAdminPresenterProvider) {
-		super(view, injector, flexibleElementsProvider.get(), importationSchemeModelsAdminPresenterProvider.get());
+	public OrgUnitModelsAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory, factory.getFlexibleElementsAdminPresenter(), factory.getImportationSchemeModelsAdminPresenter());
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/project/AddProjectModelAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/project/AddProjectModelAdminPresenter.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.presenter.admin.models.project;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -57,13 +58,12 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class AddProjectModelAdminPresenter extends AbstractPagePresenter<AddProjectModelAdminPresenter.View> implements HasForm {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(AddProjectModelAdminView.class)
+
 	public static interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -84,8 +84,7 @@ public class AddProjectModelAdminPresenter extends AbstractPagePresenter<AddProj
 	 * @param injector
 	 *          The application injector.
 	 */
-	@Inject
-	protected AddProjectModelAdminPresenter(final View view, final Injector injector) {
+	public AddProjectModelAdminPresenter(final View view, final ClientFactory injector) {
 		super(view, injector);
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/project/EditPhaseModelAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/project/EditPhaseModelAdminPresenter.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -62,13 +63,11 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class EditPhaseModelAdminPresenter extends AbstractPagePresenter<EditPhaseModelAdminPresenter.View> implements HasForm {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(EditPhaseModelAdminView.class)
 	public static interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -111,9 +110,8 @@ public class EditPhaseModelAdminPresenter extends AbstractPagePresenter<EditPhas
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected EditPhaseModelAdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public EditPhaseModelAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/project/LogFrameModelsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/project/LogFrameModelsAdminPresenter.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.inject.Injector;
@@ -67,7 +68,6 @@ public class LogFrameModelsAdminPresenter extends AbstractPresenter<LogFrameMode
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(LogFrameModelsAdminView.class)
 	public static interface View extends ViewInterface {
 
 		/**
@@ -173,9 +173,8 @@ public class LogFrameModelsAdminPresenter extends AbstractPresenter<LogFrameMode
 	 * @param injector
 	 *          The application injector.
 	 */
-	@Inject
-	public LogFrameModelsAdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public LogFrameModelsAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/project/PhaseModelsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/project/PhaseModelsAdminPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.admin.models.project;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -64,7 +66,6 @@ public class PhaseModelsAdminPresenter extends AbstractPresenter<PhaseModelsAdmi
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(PhaseModelsAdminView.class)
 	public static interface View extends ViewInterface, HasGrid<PhaseModelDTO> {
 
 		Button getAddButton();
@@ -88,9 +89,8 @@ public class PhaseModelsAdminPresenter extends AbstractPresenter<PhaseModelsAdmi
 	 * @param injector
 	 *          The application injector.
 	 */
-	@Inject
-	public PhaseModelsAdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public PhaseModelsAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/models/project/ProjectModelsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/models/project/ProjectModelsAdminPresenter.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.presenter.admin.models.project;
 
 import java.util.*;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -63,13 +64,11 @@ import com.google.inject.Singleton;
  *
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class ProjectModelsAdminPresenter extends AbstractModelsAdminPresenter<ProjectModelDTO, ProjectModelsAdminPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ProjectModelsAdminView.class)
 	public static interface View extends AbstractModelsAdminPresenter.View<ProjectModelDTO> {
 
 		void setProjectTypeProvider(ProjectTypeProvider provider);
@@ -111,10 +110,9 @@ public class ProjectModelsAdminPresenter extends AbstractModelsAdminPresenter<Pr
 	 * @param importationSchemeModelsAdminPresenterProvider
 	 *			The {@link ImportationSchemeModelsAdminPresenter} provider.
 	 */
-	@Inject
-	protected ProjectModelsAdminPresenter(final View view, final Injector injector, final Provider<FlexibleElementsAdminPresenter<ProjectModelDTO>> flexibleElementsProvider, final Provider<PhaseModelsAdminPresenter> phaseModelsAdminPresenterProvider, final Provider<LogFrameModelsAdminPresenter> logFrameModelsAdminPresenterProvider, final Provider<ImportationSchemeModelsAdminPresenter<ProjectModelDTO>> importationSchemeModelsAdminPresenterProvider) {
-		super(view, injector, flexibleElementsProvider.get(), phaseModelsAdminPresenterProvider.get(), logFrameModelsAdminPresenterProvider.get(),
-			importationSchemeModelsAdminPresenterProvider.get());
+	public ProjectModelsAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory, factory.getFlexibleElementsAdminPresenter2(), factory.getPhaseModelsAdminPresenter(), factory.getLogFrameModelsAdminPresenter(),
+			factory.getImportationSchemeModelsAdminPresenter2());
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/orgunits/AddOrgUnitAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/orgunits/AddOrgUnitAdminPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.admin.orgunits;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -57,13 +59,11 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class AddOrgUnitAdminPresenter extends AbstractPagePresenter<AddOrgUnitAdminPresenter.View> implements HasForm {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(AddOrgUnitAdminView.class)
 	public static interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -93,9 +93,8 @@ public class AddOrgUnitAdminPresenter extends AbstractPagePresenter<AddOrgUnitAd
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected AddOrgUnitAdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public AddOrgUnitAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -162,7 +161,7 @@ public class AddOrgUnitAdminPresenter extends AbstractPagePresenter<AddOrgUnitAd
 	@SuppressWarnings("deprecation")
 	private void loadCountries() {
 		view.getCountryField().getStore().removeAll();
-		view.getCountryField().getStore().add(injector.getClientCache().getCountryCache().get());
+		view.getCountryField().getStore().add(factory.getClientCache().getCountryCache().get());
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/orgunits/MoveOrgUnitAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/orgunits/MoveOrgUnitAdminPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.admin.orgunits;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -54,13 +56,11 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class MoveOrgUnitAdminPresenter extends AbstractPagePresenter<MoveOrgUnitAdminPresenter.View> implements HasForm {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(MoveOrgUnitAdminView.class)
 	public static interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -81,12 +81,11 @@ public class MoveOrgUnitAdminPresenter extends AbstractPagePresenter<MoveOrgUnit
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected MoveOrgUnitAdminPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public MoveOrgUnitAdminPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -155,7 +154,7 @@ public class MoveOrgUnitAdminPresenter extends AbstractPagePresenter<MoveOrgUnit
 		view.getParentField().getStore().removeAll();
 
 		// Retrieves the units.
-		injector.getClientCache().getOrganizationCache().get(new AsyncCallback<OrgUnitDTO>() {
+		factory.getClientCache().getOrganizationCache().get(new AsyncCallback<OrgUnitDTO>() {
 
 			@Override
 			public void onFailure(final Throwable caught) {

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/orgunits/OrgUnitsAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/orgunits/OrgUnitsAdminPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.admin.orgunits;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -66,13 +68,11 @@ import com.google.inject.Singleton;
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
 @SuppressWarnings("deprecation")
-@Singleton
 public class OrgUnitsAdminPresenter extends AbstractAdminPresenter<OrgUnitsAdminPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(OrgUnitsAdminView.class)
 	public static interface View extends AbstractAdminPresenter.View, HasTreeGrid<OrgUnitDTO> {
 
 		Button getAddButton();
@@ -101,13 +101,12 @@ public class OrgUnitsAdminPresenter extends AbstractAdminPresenter<OrgUnitsAdmin
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected OrgUnitsAdminPresenter(View view, Injector injector) {
-		super(view, injector);
-		this.localCache = injector.getClientCache();
+	public OrgUnitsAdminPresenter(View view, ClientFactory factory) {
+		super(view, factory);
+		this.localCache = factory.getClientCache();
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/users/PrivacyGroupEditPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/users/PrivacyGroupEditPresenter.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.presenter.admin.users;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -57,13 +58,11 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class PrivacyGroupEditPresenter extends AbstractPagePresenter<PrivacyGroupEditPresenter.View> {
 
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(PrivacyGroupEditView.class)
 	public static interface View extends ViewInterface {
 
 		FormPanel getForm();
@@ -90,9 +89,8 @@ public class PrivacyGroupEditPresenter extends AbstractPagePresenter<PrivacyGrou
 	 * @param injector
 	 *          The application injector.
 	 */
-	@Inject
-	protected PrivacyGroupEditPresenter(View view, Injector injector) {
-		super(view, injector);
+	public PrivacyGroupEditPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/users/ProfileEditPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/users/ProfileEditPresenter.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -67,13 +68,11 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class ProfileEditPresenter extends AbstractPagePresenter<ProfileEditPresenter.View> {
 
 	/**
 	 * The view interface managed by this presenter.
 	 */
-	@ImplementedBy(ProfileEditView.class)
 	public static interface View extends ViewInterface {
 
 		/**
@@ -144,9 +143,8 @@ public class ProfileEditPresenter extends AbstractPagePresenter<ProfileEditPrese
 	 * @param injector
 	 *          The application injector.
 	 */
-	@Inject
-	protected ProfileEditPresenter(View view, Injector injector) {
-		super(view, injector);
+	public ProfileEditPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/users/UserEditPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/users/UserEditPresenter.java
@@ -41,7 +41,7 @@ import java.util.Map;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
-import org.sigmah.client.inject.Injector;
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.page.Page;
 import org.sigmah.client.page.PageRequest;
 import org.sigmah.client.page.RequestParameter;
@@ -79,13 +79,11 @@ import org.sigmah.shared.dto.referential.ContactModelType;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) v2.0
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class UserEditPresenter extends AbstractPagePresenter<UserEditPresenter.View> {
 
 	/**
 	 * The view interface managed by this presenter.
 	 */
-	@ImplementedBy(UserEditView.class)
 	public static interface View extends ViewInterface {
 
 		/**
@@ -151,9 +149,8 @@ public class UserEditPresenter extends AbstractPagePresenter<UserEditPresenter.V
 	 * @param injector
 	 *          The application injector.
 	 */
-	@Inject
-	protected UserEditPresenter(View view, Injector injector) {
-		super(view, injector);
+	public  UserEditPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/admin/users/UsersAdminPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/admin/users/UsersAdminPresenter.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.event.handler.UpdateHandler;
@@ -75,13 +76,11 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class UsersAdminPresenter extends AbstractAdminPresenter<UsersAdminPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(UsersAdminView.class)
 	public static interface View extends AbstractAdminPresenter.View {
 
 		/**
@@ -186,12 +185,11 @@ public class UsersAdminPresenter extends AbstractAdminPresenter<UsersAdminPresen
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected UsersAdminPresenter(View view, Injector injector) {
-		super(view, injector);
+	public UsersAdminPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/base/AbstractPagePresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/base/AbstractPagePresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.base;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -87,16 +89,16 @@ public abstract class AbstractPagePresenter<V extends ViewInterface> extends Abs
 	 * 
 	 * @param view
 	 *          Page presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected application client-side injector.
 	 */
-	@Inject
-	protected AbstractPagePresenter(final V view, final Injector injector) {
+	
+	protected AbstractPagePresenter(final V view, final ClientFactory factory) {
 
-		super(view, injector); // Executes 'bind()' method.
+		super(view, factory); // Executes 'bind()' method.
 
 		// Registers page object.
-		injector.getPageManager().registerPage(this, isPopupView());
+		factory.getPageManager().registerPage(this, isPopupView());
 	}
 
 	/**
@@ -234,7 +236,7 @@ public abstract class AbstractPagePresenter<V extends ViewInterface> extends Abs
 
 		} else {
 			// Classic page.
-			injector.getApplicationPresenter().setPageTitle(title);
+			factory.getApplicationPresenter().setPageTitle(title);
 		}
 	}
 
@@ -267,7 +269,7 @@ public abstract class AbstractPagePresenter<V extends ViewInterface> extends Abs
 		if (isPopupView()) {
 			((ViewPopupInterface) view).setPageMessage(message, type);
 		} else {
-			injector.getApplicationPresenter().setPageMessage(message, type);
+			factory.getApplicationPresenter().setPageMessage(message, type);
 		}
 
 	}

--- a/src/main/java/org/sigmah/client/ui/presenter/base/AbstractPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/base/AbstractPresenter.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.presenter.base;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.Sigmah;
 import org.sigmah.client.dispatch.DispatchAsync;
 import org.sigmah.client.event.EventBus;
@@ -33,15 +34,14 @@ import org.sigmah.client.ui.presenter.base.HasSubPresenter.SubPresenter;
 import org.sigmah.client.ui.view.base.AbstractView;
 import org.sigmah.client.ui.view.base.HasSubView;
 import org.sigmah.client.ui.view.base.ViewInterface;
+import org.sigmah.client.util.profiler.Profiler;
+import org.sigmah.client.util.profiler.Scenario;
 import org.sigmah.shared.command.result.Authentication;
 
 import com.allen_sauer.gwt.log.client.Log;
 import com.extjs.gxt.ui.client.widget.LayoutContainer;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
-import com.google.inject.Inject;
-import org.sigmah.client.util.profiler.Profiler;
-import org.sigmah.client.util.profiler.Scenario;
 
 /**
  * <p>
@@ -92,7 +92,7 @@ public abstract class AbstractPresenter<V extends ViewInterface> implements Pres
 	/**
 	 * Application injector.
 	 */
-	protected final Injector injector;
+	protected final ClientFactory factory;
 
 	/**
 	 * Application command dispatcher.
@@ -118,9 +118,9 @@ public abstract class AbstractPresenter<V extends ViewInterface> implements Pres
 	 * @param injector
 	 *          Injected application injector allowing access to all useful objects.
 	 */
-	@Inject
-	protected AbstractPresenter(V view, Injector injector) {
-		this.injector = injector;
+	
+	protected AbstractPresenter(V view, ClientFactory injector) {
+		this.factory = injector;
 		this.eventBus = injector.getEventBus();
 		this.dispatch = injector.getDispatch();
 		this.view = view;
@@ -132,6 +132,8 @@ public abstract class AbstractPresenter<V extends ViewInterface> implements Pres
 
 		bind();
 	}
+
+
 
 	/**
 	 * {@inheritDoc}
@@ -226,13 +228,13 @@ public abstract class AbstractPresenter<V extends ViewInterface> implements Pres
 			placeHolder.removeAll();
 			placeHolder.add(Widget.asWidgetOrNull(getView()));
 
-			injector.getApplicationPresenter().showPresenter(parentPresenter);
+			factory.getApplicationPresenter().showPresenter(parentPresenter);
 
 			placeHolder.layout();
 
 		} else {
 			// Presenter's view is shown into application's main view.
-			injector.getApplicationPresenter().showPresenter(this);
+			factory.getApplicationPresenter().showPresenter(this);
 		}
 
 		view.onViewRevealed();
@@ -296,7 +298,7 @@ public abstract class AbstractPresenter<V extends ViewInterface> implements Pres
 	 * @return {@code true} if no user is currently authenticated, {@code false} otherwise.
 	 */
 	protected final boolean isAnonymous() {
-		return injector.getAuthenticationProvider().isAnonymous();
+		return factory.getAuthenticationProvider().isAnonymous();
 	}
 
 	/**
@@ -305,7 +307,7 @@ public abstract class AbstractPresenter<V extends ViewInterface> implements Pres
 	 * @return The current {@link Authentication}, never {@code null}.
 	 */
 	protected final Authentication auth() {
-		return injector.getAuthenticationProvider().get();
+		return factory.getAuthenticationProvider().get();
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/base/AbstractZonePresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/base/AbstractZonePresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.base;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -51,8 +53,8 @@ public abstract class AbstractZonePresenter<V extends ViewInterface> extends Abs
 	 * @param injector
 	 *          Application injector.
 	 */
-	@Inject
-	public AbstractZonePresenter(final V view, final Injector injector) {
+	
+	public AbstractZonePresenter(final V view, final ClientFactory injector) {
 		super(view, injector); // Executes 'bind()' method.
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/calendar/CalendarEventPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/calendar/CalendarEventPresenter.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -69,13 +70,11 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class CalendarEventPresenter extends AbstractPagePresenter<CalendarEventPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(CalendarEventView.class)
 	public static interface View extends ViewInterface {
 
 		FormPanel getForm();
@@ -109,9 +108,8 @@ public class CalendarEventPresenter extends AbstractPagePresenter<CalendarEventP
      * @param view Presenter's view interface.
      * @param injector Injected client injector.
 	 */
-	@Inject
-	public CalendarEventPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public CalendarEventPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/calendar/CalendarPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/calendar/CalendarPresenter.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.DispatchQueue;
 import org.sigmah.client.event.UpdateEvent;
@@ -80,7 +81,6 @@ public class CalendarPresenter extends AbstractPresenter<CalendarPresenter.View>
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(CalendarView.class)
 	public static interface View extends ViewInterface {
 
 		void initializeCalendarWidget(final CalendarWidget calendarWidget);
@@ -121,12 +121,11 @@ public class CalendarPresenter extends AbstractPresenter<CalendarPresenter.View>
 	 *
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected CalendarPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public CalendarPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/contact/ContactDetailsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/contact/ContactDetailsPresenter.java
@@ -52,6 +52,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.computation.ComputationTriggerManager;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.DispatchQueue;
@@ -115,7 +116,7 @@ import org.sigmah.shared.servlet.ServletUrlBuilder;
 import org.sigmah.shared.util.ProfileUtils;
 
 public class ContactDetailsPresenter extends AbstractPresenter<ContactDetailsPresenter.View> implements ContactPresenter.ContactSubPresenter<ContactDetailsPresenter.View>, IterableGroupPanel.Delegate {
-  @ImplementedBy(ContactDetailsView.class)
+
   public interface View extends ViewInterface {
     LayoutContainer getDetailsContainer();
 
@@ -148,12 +149,11 @@ public class ContactDetailsPresenter extends AbstractPresenter<ContactDetailsPre
 
   private FormPanel formPanel;
 
-  @Inject
-  public ContactDetailsPresenter(View view, Injector injector, ComputationTriggerManager computationTriggerManager, ImageProvider imageProvider) {
-    super(view, injector);
+  public ContactDetailsPresenter(View view, ClientFactory factory) {
+    super(view, factory);
 
-    this.computationTriggerManager = computationTriggerManager;
-    this.imageProvider = imageProvider;
+    this.computationTriggerManager = factory.getComputationTriggerManager();
+    this.imageProvider = factory.getImageProvider();
   }
 
   @Override
@@ -329,7 +329,7 @@ public class ContactDetailsPresenter extends AbstractPresenter<ContactDetailsPre
                   @Override
                   protected void onCommandSuccess(ContactDTO targetedContactDTO) {
                     dedupeContactDialog.hide();
-                    final PageRequest currentRequest = injector.getPageManager().getCurrentPageRequest(false);
+                    final PageRequest currentRequest = factory.getPageManager().getCurrentPageRequest(false);
                     eventBus.navigateRequest(Page.CONTACT_DASHBOARD.requestWith(RequestParameter.ID, targetedContactId));
                     eventBus.fireEvent(new UpdateEvent(UpdateEvent.CONTACT_DELETE, currentRequest));
                   }
@@ -483,11 +483,11 @@ public class ContactDetailsPresenter extends AbstractPresenter<ContactDetailsPre
 
           // Configures the flexible element for the current application state before generating its component.
           elementDTO.setService(dispatch);
-          elementDTO.setAuthenticationProvider(injector.getAuthenticationProvider());
+          elementDTO.setAuthenticationProvider(factory.getAuthenticationProvider());
           elementDTO.setEventBus(eventBus);
-          elementDTO.setCache(injector.getClientCache());
+          elementDTO.setCache(factory.getClientCache());
           elementDTO.setCurrentContainerDTO(contact);
-          elementDTO.setTransfertManager(injector.getTransfertManager());
+          elementDTO.setTransfertManager(factory.getTransfertManager());
           elementDTO.assignValue(valueResult);
           elementDTO.setImageProvider(imageProvider);
           if (elementDTO instanceof DefaultContactFlexibleElementDTO) {
@@ -771,7 +771,7 @@ public class ContactDetailsPresenter extends AbstractPresenter<ContactDetailsPre
           @Override
           public void onCommandSuccess(final VoidResult result) {
 
-            final PageRequest currentRequest = injector.getPageManager().getCurrentPageRequest(false);
+            final PageRequest currentRequest = factory.getPageManager().getCurrentPageRequest(false);
             eventBus.fireEvent(new UpdateEvent(UpdateEvent.CONTACT_DELETE, currentRequest));
 
             N10N.infoNotif(I18N.CONSTANTS.deleteContactNotificationTitle(), I18N.CONSTANTS.deleteContactNotificationContent());
@@ -805,7 +805,7 @@ public class ContactDetailsPresenter extends AbstractPresenter<ContactDetailsPre
       public void onExportContact(final boolean characteristicsField, final boolean allRelationsField, final boolean frameworkRelationsField, final boolean relationsByElementField) {
 
         final ServletUrlBuilder urlBuilder =
-            new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_CONTACT);
+            new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_CONTACT);
 
         urlBuilder.addParameter(RequestParameter.ID, contact.getId());
         urlBuilder.addParameter(RequestParameter.WITH_CHARACTERISTICS, characteristicsField);

--- a/src/main/java/org/sigmah/client/ui/presenter/contact/ContactHistoryPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/contact/ContactHistoryPresenter.java
@@ -29,6 +29,7 @@ import com.extjs.gxt.ui.client.widget.grid.Grid;
 
 import java.util.List;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.event.handler.UpdateHandler;
@@ -53,11 +54,10 @@ public class ContactHistoryPresenter extends AbstractPresenter<ContactHistoryPre
 
   private final ImageProvider imageProvider;
 
-  @Inject
-  public ContactHistoryPresenter(View view, Injector injector, ImageProvider imageProvider) {
-    super(view, injector);
+  public ContactHistoryPresenter(View view, ClientFactory factory) {
+    super(view, factory);
 
-    this.imageProvider = imageProvider;
+    this.imageProvider = factory.getImageProvider();
   }
 
   @Override

--- a/src/main/java/org/sigmah/client/ui/presenter/contact/ContactPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/contact/ContactPresenter.java
@@ -36,6 +36,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.TreeSet;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.inject.Injector;
 import org.sigmah.client.page.Page;
@@ -59,7 +60,7 @@ import org.sigmah.shared.dto.referential.ContactModelType;
 import com.allen_sauer.gwt.log.client.Log;
 
 public class ContactPresenter extends AbstractPagePresenter<ContactPresenter.View> {
-  @ImplementedBy(ContactView.class)
+
   public interface View extends ViewInterface {
     Component getMainComponent();
 
@@ -97,11 +98,11 @@ public class ContactPresenter extends AbstractPagePresenter<ContactPresenter.Vie
 
   private ContactDTO contactDTO;
 
-  @Inject
-  public ContactPresenter(View view, Injector injector, ContactDetailsPresenter contactDetailsPresenter, ContactRelationshipsPresenter contactRelationshipsPresenter, ContactHistoryPresenter contactHistoryPresenter, ImageProvider imageProvider) {
-    super(view, injector);
+  public ContactPresenter(View view, ClientFactory factory, ContactDetailsPresenter contactDetailsPresenter, ContactRelationshipsPresenter contactRelationshipsPresenter, ContactHistoryPresenter contactHistoryPresenter, ImageProvider imageProvider) {
+    super(view, factory);
 
     this.imageProvider = imageProvider;
+    
 
     this.tabPresenters = Arrays.asList(contactDetailsPresenter, contactRelationshipsPresenter, contactHistoryPresenter);
   }

--- a/src/main/java/org/sigmah/client/ui/presenter/contact/ContactRelationshipsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/contact/ContactRelationshipsPresenter.java
@@ -34,6 +34,7 @@ import com.extjs.gxt.ui.client.widget.grid.Grid;
 
 import java.util.List;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.i18n.I18N;
@@ -52,7 +53,8 @@ import org.sigmah.shared.servlet.ServletConstants;
 import org.sigmah.shared.servlet.ServletUrlBuilder;
 
 public class ContactRelationshipsPresenter extends AbstractPresenter<ContactRelationshipsPresenter.View> implements ContactPresenter.ContactSubPresenter<ContactRelationshipsPresenter.View> {
-  @ImplementedBy(ContactRelationshipsView.class)
+
+	
   public interface View extends ViewInterface {
     void reloadView(ContactDTO contactDTO, AnchorHandler anchorHandler);
 
@@ -78,9 +80,8 @@ public class ContactRelationshipsPresenter extends AbstractPresenter<ContactRela
     void handleClick(ContactRelationship.Type type, Integer id);
   }
 
-  @Inject
-  public ContactRelationshipsPresenter(View view, Injector injector) {
-    super(view, injector);
+  public ContactRelationshipsPresenter(View view, ClientFactory factory) {
+    super(view, factory);
   }
 
   @Override
@@ -166,7 +167,7 @@ public class ContactRelationshipsPresenter extends AbstractPresenter<ContactRela
       public void onExportContactRelationships(final boolean characteristicsField, final boolean allRelationsField, final boolean frameworkRelationsField, final boolean relationsByElementField) {
 
         final ServletUrlBuilder urlBuilder =
-            new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), ServletConstants.Servlet.EXPORT, ServletConstants.ServletMethod.EXPORT_CONTACT);
+            new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), ServletConstants.Servlet.EXPORT, ServletConstants.ServletMethod.EXPORT_CONTACT);
 
         urlBuilder.addParameter(RequestParameter.ID, contact.getId());
         urlBuilder.addParameter(RequestParameter.WITH_CHARACTERISTICS, characteristicsField);

--- a/src/main/java/org/sigmah/client/ui/presenter/contact/dashboardlist/ContactsListWidget.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/contact/dashboardlist/ContactsListWidget.java
@@ -50,6 +50,8 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Image;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -94,7 +96,7 @@ import org.sigmah.shared.util.ProfileUtils;
 
 public class ContactsListWidget extends AbstractPresenter<ContactsListWidget.View> {
 
-	@ImplementedBy(ContactsListView.class)
+	
 	public static interface View extends ViewInterface, HasGrid<DashboardContact> {
 
 		void updateAccessibilityState(boolean authorized);
@@ -127,7 +129,7 @@ public class ContactsListWidget extends AbstractPresenter<ContactsListWidget.Vie
 	private final Queue<GetContacts> commandQueue = new LinkedList<GetContacts>();
 	private CreateContactHandler createContactHandler;
 
-	@Inject
+
 	private ImageProvider imageProvider;
 
 	/**
@@ -138,10 +140,9 @@ public class ContactsListWidget extends AbstractPresenter<ContactsListWidget.Vie
 	/**
 	 * Builds a new contact list panel with default values.
 	 */
-	@Inject
-	public ContactsListWidget(final View view, final Injector injector) {
-		super(view, injector);
-
+	public ContactsListWidget(final View view, final ClientFactory factory) {
+		super(view, factory);
+		imageProvider = factory.getImageProvider();
 		createContactHandler = new CreateContactHandler() {
 			@Override
 			public void handleContactCreation(final ContactModelDTO contactModelDTO, final String email, final String firstName, final String familyName, final String organizationName, final OrgUnitDTO mainOrgUnit, final List<OrgUnitDTO> secondaryOrgUnits) {

--- a/src/main/java/org/sigmah/client/ui/presenter/contact/export/ExportContactsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/contact/export/ExportContactsPresenter.java
@@ -33,6 +33,8 @@ import com.extjs.gxt.ui.client.widget.form.Radio;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.inject.Injector;
@@ -52,10 +54,10 @@ import org.sigmah.shared.servlet.ServletConstants.ServletMethod;
 import org.sigmah.shared.servlet.ServletUrlBuilder;
 import org.sigmah.shared.util.ExportUtils.ExportDataVersion;
 
-@Singleton
+
 public class ExportContactsPresenter extends AbstractPagePresenter<ExportContactsPresenter.View> {
 
-	@ImplementedBy(ExportContactsView.class)
+
 	public static interface View extends ViewPopupInterface {
 
 		Button getSettingsButton();
@@ -78,8 +80,7 @@ public class ExportContactsPresenter extends AbstractPagePresenter<ExportContact
 
 	}
 
-	@Inject
-	protected ExportContactsPresenter(View view, Injector injector) {
+	public ExportContactsPresenter(View view, ClientFactory injector) {
 		super(view, injector);
 	}
 
@@ -129,7 +130,7 @@ public class ExportContactsPresenter extends AbstractPagePresenter<ExportContact
 			public void handleEvent(BaseEvent be) {
 
 				final ServletUrlBuilder urlBuilder =
-						new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_CONTACT_GLOBAL);
+						new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_CONTACT_GLOBAL);
 
 				urlBuilder.addParameter(RequestParameter.ID, auth().getOrganizationId());
 

--- a/src/main/java/org/sigmah/client/ui/presenter/contact/export/ExportContactsSettingPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/contact/export/ExportContactsSettingPresenter.java
@@ -35,6 +35,8 @@ import com.extjs.gxt.ui.client.widget.form.Radio;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.i18n.I18N;
@@ -54,10 +56,9 @@ import org.sigmah.shared.dto.GlobalContactExportSettingsDTO;
 import org.sigmah.shared.dto.element.FlexibleElementDTO;
 import org.sigmah.shared.util.ExportUtils;
 
-@Singleton
+
 public class ExportContactsSettingPresenter extends AbstractPagePresenter<ExportContactsSettingPresenter.View> {
 
-	@ImplementedBy(ExportContactsSettingView.class)
 	public static interface View extends ViewPopupInterface {
 
 		ListStore<FlexibleElementDTO> getFieldsStore();
@@ -102,8 +103,7 @@ public class ExportContactsSettingPresenter extends AbstractPagePresenter<Export
 
 	}
 
-	@Inject
-	public ExportContactsSettingPresenter(View view, Injector injector) {
+	public ExportContactsSettingPresenter(View view, ClientFactory injector) {
 		super(view, injector);
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/importation/ImportationPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/importation/ImportationPresenter.java
@@ -48,6 +48,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.EventBus;
@@ -110,7 +112,6 @@ public class ImportationPresenter extends AbstractPagePresenter<ImportationPrese
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ImportationView.class)
 	public static interface View extends AbstractProjectPresenter.View, HasForm {
 		Field<ImportationSchemeDTO> getSchemeField();
 		FileUploadField getFileField();
@@ -142,9 +143,8 @@ public class ImportationPresenter extends AbstractPagePresenter<ImportationPrese
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ImportationPresenter(View view, Injector injector) {
-		super(view, injector);
+	public ImportationPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 		changes = new HashMap<Integer, List<ElementExtractedValue>>();
 	}
 	
@@ -166,7 +166,7 @@ public class ImportationPresenter extends AbstractPagePresenter<ImportationPrese
 		// --
 		// Action when submitting the form.
 		// --
-		final ServletUrlBuilder servletUrlBuilder = new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), 
+		final ServletUrlBuilder servletUrlBuilder = new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), 
 			ServletConstants.Servlet.IMPORT, ServletConstants.ServletMethod.IMPORT_STORE_FILE);
 		
 		final FormPanel form = view.getForms()[0];

--- a/src/main/java/org/sigmah/client/ui/presenter/orgunit/AbstractOrgUnitPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/orgunit/AbstractOrgUnitPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.orgunit;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -65,8 +67,8 @@ public abstract class AbstractOrgUnitPresenter<V extends AbstractOrgUnitPresente
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	protected AbstractOrgUnitPresenter(final V view, final Injector injector) {
-		super(view, injector);
+	protected AbstractOrgUnitPresenter(final V view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -74,7 +76,7 @@ public abstract class AbstractOrgUnitPresenter<V extends AbstractOrgUnitPresente
 	 */
 	@Override
 	public OrgUnitPresenter getParentPresenter() {
-		return injector.getOrgUnitPresenter();
+		return factory.getOrgUnitPresenter();
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/orgunit/OrgUnitCalendarPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/orgunit/OrgUnitCalendarPresenter.java
@@ -24,20 +24,14 @@ package org.sigmah.client.ui.presenter.orgunit;
 
 import java.util.EnumMap;
 
-import org.sigmah.client.inject.Injector;
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.page.Page;
 import org.sigmah.client.page.PageRequest;
 import org.sigmah.client.ui.presenter.calendar.CalendarPresenter;
 import org.sigmah.client.ui.view.base.ViewInterface;
-import org.sigmah.client.ui.view.orgunit.OrgUnitCalendarView;
 import org.sigmah.shared.dto.calendar.CalendarType;
 import org.sigmah.shared.dto.referential.GlobalPermissionEnum;
 import org.sigmah.shared.util.ProfileUtils;
-
-import com.google.inject.ImplementedBy;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-import com.google.inject.Singleton;
 
 /**
  * <p>
@@ -50,13 +44,11 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class OrgUnitCalendarPresenter extends AbstractOrgUnitPresenter<OrgUnitCalendarPresenter.View> {
 
 	/**
 	 * Presenter's view interface.
 	 */
-	@ImplementedBy(OrgUnitCalendarView.class)
 	public static interface View extends AbstractOrgUnitPresenter.View {
 
 		/**
@@ -86,10 +78,9 @@ public class OrgUnitCalendarPresenter extends AbstractOrgUnitPresenter<OrgUnitCa
 	 * @param calendarPresenterProvider
 	 *          The {@link CalendarPresenter} provider.
 	 */
-	@Inject
-	protected OrgUnitCalendarPresenter(final View view, final Injector injector, final Provider<CalendarPresenter> calendarPresenterProvider) {
+	public OrgUnitCalendarPresenter(final View view, final ClientFactory injector) {
 		super(view, injector);
-		calendarPresenter = calendarPresenterProvider.get();
+		calendarPresenter = factory.getCalendarPresenter();
 		view.provideCalendarView(calendarPresenter.getView());
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/orgunit/OrgUnitDashboardPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/orgunit/OrgUnitDashboardPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.orgunit;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -45,13 +47,13 @@ import com.google.inject.Singleton;
  * 
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
+
 public class OrgUnitDashboardPresenter extends AbstractOrgUnitPresenter<OrgUnitDashboardPresenter.View> {
 
 	/**
 	 * Presenter's view interface.
 	 */
-	@ImplementedBy(OrgUnitDashboardView.class)
+	
 	public static interface View extends AbstractOrgUnitPresenter.View {
 
 		/**
@@ -78,9 +80,9 @@ public class OrgUnitDashboardPresenter extends AbstractOrgUnitPresenter<OrgUnitD
 
 	}
 
-	@Inject
-	public OrgUnitDashboardPresenter(View view, Injector injector) {
-		super(view, injector);
+	
+	public OrgUnitDashboardPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/orgunit/OrgUnitDetailsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/orgunit/OrgUnitDetailsPresenter.java
@@ -90,19 +90,19 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.computation.ComputationTriggerManager;
 import org.sigmah.client.event.UpdateEvent;
 
 /**
  * OrgUnit Details Presenter.
  */
-@Singleton
 public class OrgUnitDetailsPresenter extends AbstractOrgUnitPresenter<OrgUnitDetailsPresenter.View> implements IterableGroupPanel.Delegate {
 
 	/**
 	 * Presenter's view interface.
 	 */
-	@ImplementedBy(OrgUnitDetailsView.class)
 	public static interface View extends AbstractOrgUnitPresenter.View {
 
 		ContentPanel getContentOrgUnitDetailsPanel();
@@ -128,12 +128,12 @@ public class OrgUnitDetailsPresenter extends AbstractOrgUnitPresenter<OrgUnitDet
     /**
 	 * Listen to the values of flexible elements to update computated values.
 	 */
-	@Inject
 	private ComputationTriggerManager computationTriggerManager;
 
-	@Inject
-	protected OrgUnitDetailsPresenter(View view, Injector injector) {
-		super(view, injector);
+	
+	public OrgUnitDetailsPresenter(View view, ClientFactory factory) {
+		super(view, factory);
+		computationTriggerManager = factory.getComputationTriggerManager();
 	}
 
 	/**
@@ -173,7 +173,7 @@ public class OrgUnitDetailsPresenter extends AbstractOrgUnitPresenter<OrgUnitDet
 			public void handleEvent(final ButtonEvent be) {
 
 				final ServletUrlBuilder urlBuilder =
-						new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_ORG_UNIT);
+						new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_ORG_UNIT);
 
 				urlBuilder.addParameter(RequestParameter.ID, getOrgUnit().getId());
 
@@ -391,11 +391,11 @@ public class OrgUnitDetailsPresenter extends AbstractOrgUnitPresenter<OrgUnitDet
 
 						// Configures the flexible element for the current application state before generating its component.
 						elementDTO.setService(dispatch);
-						elementDTO.setAuthenticationProvider(injector.getAuthenticationProvider());
+						elementDTO.setAuthenticationProvider(factory.getAuthenticationProvider());
 						elementDTO.setEventBus(eventBus);
-						elementDTO.setCache(injector.getClientCache());
+						elementDTO.setCache(factory.getClientCache());
 					elementDTO.setCurrentContainerDTO(orgUnit);
-						elementDTO.setTransfertManager(injector.getTransfertManager());
+						elementDTO.setTransfertManager(factory.getTransfertManager());
 						elementDTO.assignValue(valueResult);
 					elementDTO.setTabPanel(tabPanel);
 

--- a/src/main/java/org/sigmah/client/ui/presenter/orgunit/OrgUnitPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/orgunit/OrgUnitPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.orgunit;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -68,13 +70,11 @@ import org.sigmah.shared.dto.referential.GlobalPermissionEnum;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class OrgUnitPresenter extends AbstractPresenter<OrgUnitPresenter.View> implements HasSubPresenter<OrgUnitPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(OrgUnitView.class)
 	public static interface View extends HasSubView {
 
 		/**
@@ -114,12 +114,11 @@ public class OrgUnitPresenter extends AbstractPresenter<OrgUnitPresenter.View> i
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	public OrgUnitPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public OrgUnitPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -134,7 +133,7 @@ public class OrgUnitPresenter extends AbstractPresenter<OrgUnitPresenter.View> i
 			@Override
 			public void onSubMenuClick(final SubMenuItem menuItem) {
 
-				final PageRequest currentPageRequest = injector.getPageManager().getCurrentPageRequest(false);
+				final PageRequest currentPageRequest = factory.getPageManager().getCurrentPageRequest(false);
 				eventBus.navigateRequest(menuItem.getRequest().addAllParameters(currentPageRequest.getParameters(true)));
 
 			}
@@ -235,8 +234,8 @@ public class OrgUnitPresenter extends AbstractPresenter<OrgUnitPresenter.View> i
 					// Builds the graphic component
 					final DefaultFlexibleElementDTO defaultElement = (DefaultFlexibleElementDTO) element;
 					defaultElement.setService(dispatch);
-					defaultElement.setAuthenticationProvider(injector.getAuthenticationProvider());
-					defaultElement.setCache(injector.getClientCache());
+					defaultElement.setAuthenticationProvider(factory.getAuthenticationProvider());
+					defaultElement.setCache(factory.getClientCache());
 					defaultElement.setCurrentContainerDTO(orgUnit);
 
 					dispatch.execute(new GetValue(orgUnit.getId(), defaultElement.getId(), defaultElement.getEntityName(), null),

--- a/src/main/java/org/sigmah/client/ui/presenter/orgunit/OrgUnitReportsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/orgunit/OrgUnitReportsPresenter.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.presenter.orgunit;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.inject.Injector;
 import org.sigmah.client.page.Page;
@@ -56,13 +57,11 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class OrgUnitReportsPresenter extends AbstractOrgUnitPresenter<OrgUnitReportsPresenter.View> {
 
 	/**
 	 * Presenter's view interface.
 	 */
-	@ImplementedBy(OrgUnitReportsView.class)
 	public static interface View extends AbstractOrgUnitPresenter.View {
 
 		/**
@@ -82,10 +81,9 @@ public class OrgUnitReportsPresenter extends AbstractOrgUnitPresenter<OrgUnitRep
 	 */
 	private final ReportsPresenter reportsPresenter;
 
-	@Inject
-	public OrgUnitReportsPresenter(View view, Injector injector, Provider<ReportsPresenter> reportsPresenterProvider) {
-		super(view, injector);
-		reportsPresenter = reportsPresenterProvider.get();
+	public OrgUnitReportsPresenter(View view, ClientFactory factory) {
+		super(view, factory);
+		reportsPresenter = factory.getReportsPresenter();
 		view.provideReportsView(reportsPresenter.getView());
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/password/ChangeOwnPasswordPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/password/ChangeOwnPasswordPresenter.java
@@ -28,6 +28,8 @@ import com.extjs.gxt.ui.client.widget.form.Field;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.inject.Injector;
@@ -47,13 +49,12 @@ import org.sigmah.shared.command.result.VoidResult;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class ChangeOwnPasswordPresenter extends AbstractPagePresenter<ChangeOwnPasswordPresenter.View> {
 	
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ChangeOwnPasswordView.class)
 	public static interface View extends ViewInterface {
 
 		FormPanel getForm();
@@ -78,8 +79,7 @@ public class ChangeOwnPasswordPresenter extends AbstractPagePresenter<ChangeOwnP
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ChangeOwnPasswordPresenter(final ChangeOwnPasswordPresenter.View view, final Injector injector) {
+	public ChangeOwnPasswordPresenter(final ChangeOwnPasswordPresenter.View view, final ClientFactory injector) {
 		super(view, injector);
 	}
 	

--- a/src/main/java/org/sigmah/client/ui/presenter/password/LostPasswordPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/password/LostPasswordPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.password;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -55,21 +57,18 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class LostPasswordPresenter extends AbstractPagePresenter<LostPasswordPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(LostPasswordView.class)
 	public static interface View extends ViewInterface {
-
 		FormPanel getForm();
 
 		Field<String> getEmailField();
 
 		Button getValidateButton();
-
 	}
 
 	/**
@@ -85,9 +84,8 @@ public class LostPasswordPresenter extends AbstractPagePresenter<LostPasswordPre
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public LostPasswordPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public LostPasswordPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/password/ResetPasswordPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/password/ResetPasswordPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.password;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -53,13 +55,11 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ResetPasswordPresenter extends AbstractPagePresenter<ResetPasswordPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ResetPasswordView.class)
 	public static interface View extends ViewInterface {
 
 		ValueBoxBase<String> getEmailField();
@@ -93,9 +93,8 @@ public class ResetPasswordPresenter extends AbstractPagePresenter<ResetPasswordP
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ResetPasswordPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public ResetPasswordPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/project/AbstractProjectPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/AbstractProjectPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.project;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -68,8 +70,8 @@ public abstract class AbstractProjectPresenter<V extends AbstractProjectPresente
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	public AbstractProjectPresenter(final V view, final Injector injector) {
-		super(view, injector);
+	public AbstractProjectPresenter(final V view, final ClientFactory factory) {
+		super(view, factory);
 	}
 	
 	/**
@@ -153,7 +155,7 @@ public abstract class AbstractProjectPresenter<V extends AbstractProjectPresente
 	 */
 	@Override
 	public ProjectPresenter getParentPresenter() {
-		return injector.getProjectPresenter();
+		return factory.getProjectPresenter();
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/project/LinkedProjectPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/LinkedProjectPresenter.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -89,13 +90,11 @@ import org.sigmah.shared.dto.element.BudgetRatioElementDTO;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class LinkedProjectPresenter extends AbstractPagePresenter<LinkedProjectPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(LinkedProjectView.class)
 	public static interface View extends ViewInterface {
 
 		/**
@@ -204,8 +203,7 @@ public class LinkedProjectPresenter extends AbstractPagePresenter<LinkedProjectP
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public LinkedProjectPresenter(final View view, final Injector injector) {
+	public LinkedProjectPresenter(final View view, final ClientFactory injector) {
 		super(view, injector);
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/project/ProjectCalendarPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/ProjectCalendarPresenter.java
@@ -24,6 +24,7 @@ package org.sigmah.client.ui.presenter.project;
 
 import java.util.EnumMap;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.inject.Injector;
 import org.sigmah.client.page.Page;
 import org.sigmah.client.page.PageRequest;
@@ -52,13 +53,11 @@ import org.sigmah.client.util.profiler.Scenario;
  *
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ProjectCalendarPresenter extends AbstractProjectPresenter<ProjectCalendarPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ProjectCalendarView.class)
 	public static interface View extends AbstractProjectPresenter.View {
 
 		/**
@@ -82,15 +81,14 @@ public class ProjectCalendarPresenter extends AbstractProjectPresenter<ProjectCa
 	 *
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 * @param calendarPresenterProvider
 	 *          The {@link CalendarPresenter} provider.
 	 */
-	@Inject
-	public ProjectCalendarPresenter(final View view, final Injector injector, final Provider<CalendarPresenter> calendarPresenterProvider) {
-		super(view, injector);
-		calendarPresenter = calendarPresenterProvider.get();
+	public ProjectCalendarPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
+		calendarPresenter = factory.getCalendarPresenter();
 		view.provideCalendarView(calendarPresenter.getView());
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/project/ProjectDetailsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/ProjectDetailsPresenter.java
@@ -93,6 +93,8 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.computation.ComputationTriggerManager;
 import org.sigmah.client.util.profiler.Profiler;
 import org.sigmah.client.util.profiler.Scenario;
@@ -102,7 +104,6 @@ import org.sigmah.client.util.profiler.Scenario;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ProjectDetailsPresenter extends AbstractProjectPresenter<ProjectDetailsPresenter.View> implements IterableGroupPanel.Delegate {
 
 	// CSS style names.
@@ -111,7 +112,6 @@ public class ProjectDetailsPresenter extends AbstractProjectPresenter<ProjectDet
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ProjectDetailsView.class)
 	public static interface View extends AbstractProjectPresenter.View {
 
 		LayoutContainer getMainPanel();
@@ -134,7 +134,7 @@ public class ProjectDetailsPresenter extends AbstractProjectPresenter<ProjectDet
 	/**
 	 * Listen to the values of flexible elements to update computated values.
 	 */
-	@Inject
+	
 	private ComputationTriggerManager computationTriggerManager;
 
 	/**
@@ -142,12 +142,12 @@ public class ProjectDetailsPresenter extends AbstractProjectPresenter<ProjectDet
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ProjectDetailsPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public ProjectDetailsPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
+		computationTriggerManager = factory.getComputationTriggerManager();
 	}
 
 	/**
@@ -400,15 +400,15 @@ public class ProjectDetailsPresenter extends AbstractProjectPresenter<ProjectDet
 
 						// Configures the flexible element for the current application state before generating its component.
 						elementDTO.setService(dispatch);
-						elementDTO.setAuthenticationProvider(injector.getAuthenticationProvider());
+						elementDTO.setAuthenticationProvider(factory.getAuthenticationProvider());
 						elementDTO.setEventBus(eventBus);
-						elementDTO.setCache(injector.getClientCache());
+						elementDTO.setCache(factory.getClientCache());
 					elementDTO.setCurrentContainerDTO(project);
-                        elementDTO.setTransfertManager(injector.getTransfertManager());
+                        elementDTO.setTransfertManager(factory.getTransfertManager());
 						elementDTO.assignValue(valueResult);
 					elementDTO.setTabPanel(tabPanel);
 						
-						final ProjectPresenter projectPresenter = injector.getProjectPresenter();
+						final ProjectPresenter projectPresenter = factory.getProjectPresenter();
 
 						// Generates element component (with the value).
 						elementDTO.init();

--- a/src/main/java/org/sigmah/client/ui/presenter/project/ProjectReportsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/ProjectReportsPresenter.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.presenter.project;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.inject.Injector;
 import org.sigmah.client.page.Page;
@@ -59,13 +60,11 @@ import org.sigmah.shared.dto.element.FlexibleElementDTO;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ProjectReportsPresenter extends AbstractProjectPresenter<ProjectReportsPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ProjectReportsView.class)
 	public static interface View extends AbstractProjectPresenter.View {
 
 		/**
@@ -90,13 +89,12 @@ public class ProjectReportsPresenter extends AbstractProjectPresenter<ProjectRep
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ProjectReportsPresenter(final View view, final Injector injector, final Provider<ReportsPresenter> reportsPresenterProvider) {
-		super(view, injector);
-		reportsPresenter = reportsPresenterProvider.get();
+	public ProjectReportsPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
+		reportsPresenter = factory.getReportsPresenter();
 		view.provideReportsView(reportsPresenter.getView());
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/project/ProjectTeamMembersPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/ProjectTeamMembersPresenter.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.i18n.I18N;
@@ -64,7 +65,6 @@ import org.sigmah.shared.util.ProfileUtils;
  *
  * @author Aurélien PONÇON (aurelien.poncon@gmail.com)
  */
-@Singleton
 public class ProjectTeamMembersPresenter extends AbstractProjectPresenter<ProjectTeamMembersPresenter.View> {
 	/**
 	 * Description of the view managed by this presenter.
@@ -107,9 +107,8 @@ public class ProjectTeamMembersPresenter extends AbstractProjectPresenter<Projec
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ProjectTeamMembersPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public ProjectTeamMembersPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/project/dashboard/PhasesPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/dashboard/PhasesPresenter.java
@@ -108,6 +108,8 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Grid;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.computation.ComputationTriggerManager;
 import org.sigmah.client.ui.presenter.project.ProjectPresenter;
 import org.sigmah.client.ui.widget.Loadable;
@@ -125,7 +127,6 @@ public class PhasesPresenter extends AbstractPresenter<PhasesPresenter.View> imp
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(PhasesView.class)
 	public static interface View extends ViewInterface, Loadable {
 
 		/**
@@ -219,7 +220,6 @@ public class PhasesPresenter extends AbstractPresenter<PhasesPresenter.View> imp
 	/**
 	 * Listen to the values of flexible elements to update computated values.
 	 */
-	@Inject
 	private ComputationTriggerManager computationTriggerManager;
 	
 	/**
@@ -230,9 +230,9 @@ public class PhasesPresenter extends AbstractPresenter<PhasesPresenter.View> imp
 	 * @param injector
 	 *          The application injector.
 	 */
-	@Inject
-	protected PhasesPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public PhasesPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
+		this.computationTriggerManager = factory.getComputationTriggerManager();
 	}
 
 	/**
@@ -285,19 +285,19 @@ public class PhasesPresenter extends AbstractPresenter<PhasesPresenter.View> imp
 	}
 
 	private ProjectDTO getCurrentProject() {
-		return injector.getProjectPresenter().getCurrentProject();
+		return factory.getProjectPresenter().getCurrentProject();
 	}
 
 	private void setCurrentProject(final ProjectDTO project) {
-		injector.getProjectPresenter().setCurrentProject(project);
+		factory.getProjectPresenter().setCurrentProject(project);
 	}
 
 	private PhaseDTO getCurrentDisplayedPhase() {
-		return injector.getProjectPresenter().getCurrentDisplayedPhase();
+		return factory.getProjectPresenter().getCurrentDisplayedPhase();
 	}
 
 	private void setCurrentDisplayedPhase(final PhaseDTO phase) {
-		injector.getProjectPresenter().setCurrentDisplayedPhase(phase);
+		factory.getProjectPresenter().setCurrentDisplayedPhase(phase);
 	}
 
 	/**
@@ -583,7 +583,7 @@ public class PhasesPresenter extends AbstractPresenter<PhasesPresenter.View> imp
 			protected void onComplete() {
 				// View layouts update.
 				// FIXME (v1.3) This should be done by Ext, not be the developer!
-				injector.getProjectDashboardPresenter().getView().layoutView();
+				factory.getProjectDashboardPresenter().getView().layoutView();
 				view.layout();				
 				Profiler.INSTANCE.endScenario(Scenario.OPEN_PROJECT);
 			}
@@ -768,15 +768,15 @@ public class PhasesPresenter extends AbstractPresenter<PhasesPresenter.View> imp
 
 							// Configures the flexible element for the current application state before generating its component.
 							elementDTO.setService(dispatch);
-							elementDTO.setAuthenticationProvider(injector.getAuthenticationProvider());
+							elementDTO.setAuthenticationProvider(factory.getAuthenticationProvider());
 					elementDTO.setEventBus(eventBus);
-							elementDTO.setCache(injector.getClientCache());
+							elementDTO.setCache(factory.getClientCache());
 					elementDTO.setCurrentContainerDTO(project);
-							elementDTO.setTransfertManager(injector.getTransfertManager());
+							elementDTO.setTransfertManager(factory.getTransfertManager());
 							elementDTO.assignValue(valueResult);
 					elementDTO.setTabPanel(tabPanel);
 
-							final ProjectPresenter projectPresenter = injector.getProjectPresenter();
+							final ProjectPresenter projectPresenter = factory.getProjectPresenter();
 							
 							// Generates element component (with the value).
 							elementDTO.init();

--- a/src/main/java/org/sigmah/client/ui/presenter/project/dashboard/ProjectDashboardPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/dashboard/ProjectDashboardPresenter.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -89,13 +90,13 @@ import org.sigmah.shared.util.ProjectUtils;
  * @author Denis Colliot (dcolliot@ideia.fr)
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class ProjectDashboardPresenter extends AbstractProjectPresenter<ProjectDashboardPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ProjectDashboardView.class)
+	
 	public static interface View extends AbstractProjectPresenter.View {
 
 		/**
@@ -205,8 +206,8 @@ public class ProjectDashboardPresenter extends AbstractProjectPresenter<ProjectD
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ProjectDashboardPresenter(final View view, final Injector injector) {
+	
+	public ProjectDashboardPresenter(final View view, final ClientFactory injector) {
 		super(view, injector);
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/project/export/ExportProjectsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/export/ExportProjectsPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.project.export;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -56,10 +58,8 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class ExportProjectsPresenter extends AbstractPagePresenter<ExportProjectsPresenter.View> {
 
-	@ImplementedBy(ExportProjectsView.class)
 	public static interface View extends ViewPopupInterface {
 
 		Button getSettingsButton();
@@ -82,9 +82,8 @@ public class ExportProjectsPresenter extends AbstractPagePresenter<ExportProject
 
 	}
 
-	@Inject
-	protected ExportProjectsPresenter(View view, Injector injector) {
-		super(view, injector);
+	public ExportProjectsPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override
@@ -133,7 +132,7 @@ public class ExportProjectsPresenter extends AbstractPagePresenter<ExportProject
 			public void handleEvent(BaseEvent be) {
 
 				final ServletUrlBuilder urlBuilder =
-						new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_GLOBAL);
+						new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_GLOBAL);
 
 				urlBuilder.addParameter(RequestParameter.ID, auth().getOrganizationId());
 

--- a/src/main/java/org/sigmah/client/ui/presenter/project/export/ExportProjectsSettingPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/export/ExportProjectsSettingPresenter.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.presenter.project.export;
 import java.util.List;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.i18n.I18N;
@@ -58,10 +59,8 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class ExportProjectsSettingPresenter extends AbstractPagePresenter<ExportProjectsSettingPresenter.View> {
 
-	@ImplementedBy(ExportProjectsSettingView.class)
 	public static interface View extends ViewPopupInterface {
 
 		ListStore<FlexibleElementDTO> getFieldsStore();
@@ -106,9 +105,8 @@ public class ExportProjectsSettingPresenter extends AbstractPagePresenter<Export
 
 	}
 
-	@Inject
-	public ExportProjectsSettingPresenter(View view, Injector injector) {
-		super(view, injector);
+	public ExportProjectsSettingPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override

--- a/src/main/java/org/sigmah/client/ui/presenter/project/indicator/EditIndicatorPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/indicator/EditIndicatorPresenter.java
@@ -37,6 +37,8 @@ import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.List;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -76,13 +78,11 @@ import org.sigmah.shared.dto.pivot.model.PivotTableElement;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class EditIndicatorPresenter extends AbstractPagePresenter<EditIndicatorPresenter.View> implements HasForm {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(EditIndicatorView.class)
 	public static interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -124,12 +124,11 @@ public class EditIndicatorPresenter extends AbstractPagePresenter<EditIndicatorP
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected EditIndicatorPresenter(final EditIndicatorPresenter.View view, final Injector injector) {
-		super(view, injector);
+	public EditIndicatorPresenter(final EditIndicatorPresenter.View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 	
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/project/indicator/EditSitePresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/indicator/EditSitePresenter.java
@@ -39,6 +39,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.SiteEvent;
@@ -77,13 +79,11 @@ import org.sigmah.shared.dto.country.CountryDTO;
  *
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class EditSitePresenter extends AbstractPagePresenter<EditSitePresenter.View> implements HasForm {
 	
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(EditSiteView.class)
 	public static interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -118,8 +118,7 @@ public class EditSitePresenter extends AbstractPagePresenter<EditSitePresenter.V
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected EditSitePresenter(final EditSitePresenter.View view, final Injector injector) {
+	public EditSitePresenter(final EditSitePresenter.View view, final ClientFactory injector) {
 		super(view, injector);
 	}
 	

--- a/src/main/java/org/sigmah/client/ui/presenter/project/indicator/ProjectIndicatorEntriesPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/indicator/ProjectIndicatorEntriesPresenter.java
@@ -36,6 +36,8 @@ import org.sigmah.client.ui.view.project.indicator.ProjectIndicatorEntriesView;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.EventBus;
 import org.sigmah.client.page.RequestParameter;
@@ -52,13 +54,11 @@ import org.sigmah.shared.util.ProfileUtils;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ProjectIndicatorEntriesPresenter extends AbstractProjectPresenter<ProjectIndicatorEntriesPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ProjectIndicatorEntriesView.class)
 	public static interface View extends AbstractProjectPresenter.View {
 		ProjectPivotContainer getProjectPivotContainer();
 	}
@@ -71,8 +71,7 @@ public class ProjectIndicatorEntriesPresenter extends AbstractProjectPresenter<P
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ProjectIndicatorEntriesPresenter(final View view, final Injector injector) {
+	public ProjectIndicatorEntriesPresenter(final View view, final ClientFactory injector) {
 		super(view, injector);
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/project/indicator/ProjectIndicatorManagementPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/indicator/ProjectIndicatorManagementPresenter.java
@@ -44,6 +44,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.HashMap;
 import java.util.List;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -85,13 +87,11 @@ import org.sigmah.shared.util.ProfileUtils;
  * @author Denis Colliot (dcolliot@ideia.fr)
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ProjectIndicatorManagementPresenter extends AbstractProjectPresenter<ProjectIndicatorManagementPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ProjectIndicatorManagementView.class)
 	public static interface View extends AbstractProjectPresenter.View, HasTreeGrid<IndicatorElement> {
 		SplitButton getSaveButton();
 		MenuItem getSaveItem();
@@ -118,12 +118,11 @@ public class ProjectIndicatorManagementPresenter extends AbstractProjectPresente
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ProjectIndicatorManagementPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public ProjectIndicatorManagementPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -356,7 +355,7 @@ public class ProjectIndicatorManagementPresenter extends AbstractProjectPresente
 	
 	private void onExport() {
 		final ServletUrlBuilder urlBuilder =
-				new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), ServletConstants.Servlet.EXPORT, ServletConstants.ServletMethod.EXPORT_PROJECT_INDICATORS);
+				new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), ServletConstants.Servlet.EXPORT, ServletConstants.ServletMethod.EXPORT_PROJECT_INDICATORS);
 		
 		urlBuilder.addParameter(RequestParameter.ID, getProject().getId());
 

--- a/src/main/java/org/sigmah/client/ui/presenter/project/indicator/ProjectIndicatorMapPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/indicator/ProjectIndicatorMapPresenter.java
@@ -36,6 +36,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.SiteEvent;
@@ -65,13 +67,11 @@ import org.sigmah.shared.util.Filter;
  * @author sherzod
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ProjectIndicatorMapPresenter extends AbstractProjectPresenter<ProjectIndicatorMapPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ProjectIndicatorMapView.class)
 	public static interface View extends AbstractProjectPresenter.View {
 		SiteGridPanel getSiteGridPanel();
 		WorldMap getWorldMap();
@@ -93,9 +93,8 @@ public class ProjectIndicatorMapPresenter extends AbstractProjectPresenter<Proje
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ProjectIndicatorMapPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public ProjectIndicatorMapPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/project/logframe/ProjectLogFramePresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/logframe/ProjectLogFramePresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.project.logframe;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -67,13 +69,11 @@ import com.google.inject.Singleton;
  * @author Denis Colliot (dcolliot@ideia.fr)
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
 public class ProjectLogFramePresenter extends AbstractProjectPresenter<ProjectLogFramePresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ProjectLogFrameView.class)
 	public static interface View extends AbstractProjectPresenter.View {
 
 		Component getMainPanel();
@@ -119,12 +119,11 @@ public class ProjectLogFramePresenter extends AbstractProjectPresenter<ProjectLo
 	 *
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ProjectLogFramePresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public ProjectLogFramePresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -201,7 +200,7 @@ public class ProjectLogFramePresenter extends AbstractProjectPresenter<ProjectLo
 			public void handleEvent(final ButtonEvent be) {
 
 				final ServletUrlBuilder urlBuilder =
-						new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_PROJECT_LOGFRAME);
+						new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_PROJECT_LOGFRAME);
 
 				urlBuilder.addParameter(RequestParameter.ID, getProject().getId());
 

--- a/src/main/java/org/sigmah/client/ui/presenter/project/projectcore/ProjectCoreDiffPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/projectcore/ProjectCoreDiffPresenter.java
@@ -26,6 +26,7 @@ package org.sigmah.client.ui.presenter.project.projectcore;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.inject.Injector;
@@ -62,7 +63,6 @@ import org.sigmah.shared.command.result.Result;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ProjectCoreDiffPresenter extends AbstractPagePresenter<ProjectCoreDiffPresenter.View> {
 	
 	private static final int LEFT = 0;
@@ -72,7 +72,6 @@ public class ProjectCoreDiffPresenter extends AbstractPagePresenter<ProjectCoreD
 
 	private boolean show = true;
 
-	@ImplementedBy(ProjectCoreDiffView.class)
 	public static interface View extends ViewPopupInterface {
 
 		ContentPanel getMainPanel();
@@ -91,9 +90,8 @@ public class ProjectCoreDiffPresenter extends AbstractPagePresenter<ProjectCoreD
 
 	}
 
-	@Inject
-	protected ProjectCoreDiffPresenter(View view, Injector injector) {
-		super(view, injector);
+	public ProjectCoreDiffPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override
@@ -164,7 +162,7 @@ public class ProjectCoreDiffPresenter extends AbstractPagePresenter<ProjectCoreD
 		for (FlexibleElementDTO field : project.getProjectModel().getAllElements()) {
 			if (field.getAmendable()) {
 				// BUGFIX #728: Using the cache to resolve users and countries.
-				field.setCache(injector.getClientCache());
+				field.setCache(factory.getClientCache());
 				
 				DiffEntry entry = new DiffEntry();
 				entry.setField(field);

--- a/src/main/java/org/sigmah/client/ui/presenter/project/projectcore/ProjectCoreRenameVersionPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/projectcore/ProjectCoreRenameVersionPresenter.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.presenter.project.projectcore;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -55,12 +56,10 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class ProjectCoreRenameVersionPresenter extends AbstractPagePresenter<ProjectCoreRenameVersionPresenter.View> {
 
 	private boolean show = true;
 
-	@ImplementedBy(ProjectCoreRenameVersionView.class)
 	public static interface View extends ViewPopupInterface {
 
 		ContentPanel getMainPanel();
@@ -75,9 +74,8 @@ public class ProjectCoreRenameVersionPresenter extends AbstractPagePresenter<Pro
 
 	}
 
-	@Inject
-	protected ProjectCoreRenameVersionPresenter(View view, Injector injector) {
-		super(view, injector);
+	public ProjectCoreRenameVersionPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	@Override

--- a/src/main/java/org/sigmah/client/ui/presenter/project/treegrid/ProjectsListWidget.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/project/treegrid/ProjectsListWidget.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -107,7 +108,7 @@ public class ProjectsListWidget extends AbstractPresenter<ProjectsListWidget.Vie
 	 *
 	 * @author Denis Colliot (dcolliot@ideia.fr)
 	 */
-	@ImplementedBy(ProjectsListView.class)
+
 	public static interface View extends ViewInterface, HasTreeGrid<ProjectDTO> {
 
 		/**
@@ -306,9 +307,9 @@ public class ProjectsListWidget extends AbstractPresenter<ProjectsListWidget.Vie
 	/**
 	 * Builds a new project list panel with default values.
 	 */
-	@Inject
-	public ProjectsListWidget(final View view, final Injector injector) {
-		super(view, injector);
+
+	public ProjectsListWidget(final View view, final ClientFactory factory) {
+		super(view, factory);
 		this.orgUnitsIds = new ArrayList<Integer>();
 
 		// Default values.

--- a/src/main/java/org/sigmah/client/ui/presenter/reminder/ReminderEditPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/reminder/ReminderEditPresenter.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.presenter.reminder;
 import java.util.Date;
 import java.util.HashMap;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -62,13 +63,11 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ReminderEditPresenter extends AbstractPagePresenter<ReminderEditPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ReminderEditView.class)
 	public static interface View extends ViewInterface {
 
 		/**
@@ -132,12 +131,11 @@ public class ReminderEditPresenter extends AbstractPagePresenter<ReminderEditPre
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ReminderEditPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public ReminderEditPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/reminder/ReminderHistoryPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/reminder/ReminderHistoryPresenter.java
@@ -24,6 +24,7 @@ package org.sigmah.client.ui.presenter.reminder;
 
 import java.util.List;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.inject.Injector;
 import org.sigmah.client.page.Page;
 import org.sigmah.client.page.PageRequest;
@@ -46,13 +47,11 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ReminderHistoryPresenter extends AbstractPagePresenter<ReminderHistoryPresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ReminderHistoryView.class)
 	public static interface View extends ViewInterface {
 
 		void setData(List<? extends AbstractModelDataEntityDTO<?>> dataList);
@@ -73,9 +72,8 @@ public class ReminderHistoryPresenter extends AbstractPagePresenter<ReminderHist
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ReminderHistoryPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public ReminderHistoryPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/reports/AttachFilePresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/reports/AttachFilePresenter.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.presenter.reports;
 
 import java.util.Date;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.inject.Injector;
@@ -69,13 +70,11 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class AttachFilePresenter extends AbstractPagePresenter<AttachFilePresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(AttachFileView.class)
 	public static interface View extends ViewPopupInterface {
 
 		FormPanel getForm();
@@ -122,12 +121,11 @@ public class AttachFilePresenter extends AbstractPagePresenter<AttachFilePresent
 	 * 
 	 * @param view
 	 *          Presenter's view interface.
-	 * @param injector
+	 * @param factory
 	 *          Injected client injector.
 	 */
-	@Inject
-	public AttachFilePresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public AttachFilePresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -229,7 +227,7 @@ public class AttachFilePresenter extends AbstractPagePresenter<AttachFilePresent
 	 */
 	private void onFileChange() {
 
-		if (!injector.getTransfertManager().canUpload()) {
+		if (!factory.getTransfertManager().canUpload()) {
 			N10N.warn(I18N.CONSTANTS.flexibleElementFilesListUploadUnable());
 			return;
 		}
@@ -266,7 +264,7 @@ public class AttachFilePresenter extends AbstractPagePresenter<AttachFilePresent
 
 		view.setLoading(true);
 
-		injector.getTransfertManager().upload(view.getForm(), new ProgressListener() {
+		factory.getTransfertManager().upload(view.getForm(), new ProgressListener() {
 
 			@Override
 			public void onProgress(final double progress, final double speed) {

--- a/src/main/java/org/sigmah/client/ui/presenter/reports/ReportCreatePresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/reports/ReportCreatePresenter.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.i18n.I18N;
@@ -62,13 +63,12 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class ReportCreatePresenter extends AbstractPagePresenter<ReportCreatePresenter.View> {
 
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ReportCreateView.class)
 	public static interface View extends ViewInterface {
 
 		FormPanel getForm();
@@ -111,9 +111,8 @@ public class ReportCreatePresenter extends AbstractPagePresenter<ReportCreatePre
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	public ReportCreatePresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public ReportCreatePresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**
@@ -267,7 +266,7 @@ public class ReportCreatePresenter extends AbstractPagePresenter<ReportCreatePre
 	 */
 	private final String getIdPropertyKey() {
 
-		final Page page = injector.getPageManager().getCurrentPage(false);
+		final Page page = factory.getPageManager().getCurrentPage(false);
 
 		switch (page) {
 

--- a/src/main/java/org/sigmah/client/ui/presenter/reports/ReportsPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/reports/ReportsPresenter.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.event.UpdateEvent;
@@ -39,7 +40,6 @@ import org.sigmah.client.page.RequestParameter;
 import org.sigmah.client.ui.notif.N10N;
 import org.sigmah.client.ui.presenter.base.AbstractPresenter;
 import org.sigmah.client.ui.view.base.ViewInterface;
-import org.sigmah.client.ui.view.reports.ReportsView;
 import org.sigmah.client.ui.widget.button.Button;
 import org.sigmah.client.ui.widget.panel.FoldPanel;
 import org.sigmah.client.util.ClientConfiguration;
@@ -88,10 +88,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasHTML;
 import com.google.gwt.user.client.ui.RootPanel;
-import com.google.inject.ImplementedBy;
-import com.google.inject.Inject;
 import org.sigmah.shared.file.TransfertManager;
-
 /**
  * Reports & Documents widget presenter.
  * 
@@ -102,12 +99,8 @@ public class ReportsPresenter extends AbstractPresenter<ReportsPresenter.View> {
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(ReportsView.class)
-	public static interface View extends ViewInterface {
 
-		// --
-		// Documents (reports / files) lists area.
-		// --
+	public static interface View extends ViewInterface {
 
 		void setDocumentNameColumnActionHandler(DocumentNameColumnActionHandler documentNameColumnActionHandler);
 
@@ -240,7 +233,7 @@ public class ReportsPresenter extends AbstractPresenter<ReportsPresenter.View> {
 	 */
 	private String phaseName;
 	
-	@Inject
+	
 	private TransfertManager transfertManager;
 
 	/**
@@ -251,9 +244,9 @@ public class ReportsPresenter extends AbstractPresenter<ReportsPresenter.View> {
 	 * @param injector
 	 *          Injected client injector.
 	 */
-	@Inject
-	protected ReportsPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public ReportsPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
+		transfertManager = factory.getTransfertManager();
 	}
 
 	/**
@@ -922,7 +915,7 @@ public class ReportsPresenter extends AbstractPresenter<ReportsPresenter.View> {
 	private void onExportReport(final ProjectReportDTO report) {
 
 		final ServletUrlBuilder urlBuilder =
-				new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_REPORT);
+				new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), Servlet.EXPORT, ServletMethod.EXPORT_REPORT);
 
 		urlBuilder.addParameter(RequestParameter.ID, report.getId());
 		urlBuilder.addParameter(RequestParameter.TYPE, ExportType.PROJECT_REPORT);

--- a/src/main/java/org/sigmah/client/ui/presenter/zone/AppLoaderPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/zone/AppLoaderPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.zone;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -43,13 +45,13 @@ import com.google.inject.Singleton;
  * @author Denis Colliot (dcolliot@ideia.fr)
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class AppLoaderPresenter extends AbstractZonePresenter<AppLoaderPresenter.View> {
 
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(AppLoaderView.class)
+	
 	public static interface View extends ViewInterface {
 
 		Panel getLoaderPanel();
@@ -64,9 +66,9 @@ public class AppLoaderPresenter extends AbstractZonePresenter<AppLoaderPresenter
 
 	}
 
-	@Inject
-	public AppLoaderPresenter(View view, Injector injector) {
-		super(view, injector);
+
+	public AppLoaderPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/zone/AuthenticationBannerPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/zone/AuthenticationBannerPresenter.java
@@ -43,6 +43,8 @@ import com.google.gwt.user.client.ui.Panel;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.page.Page;
 import org.sigmah.client.ui.notif.ConfirmCallback;
@@ -55,7 +57,7 @@ import org.sigmah.shared.util.ProfileUtils;
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class AuthenticationBannerPresenter extends AbstractZonePresenter<AuthenticationBannerPresenter.View> {
 
 	private boolean canChangeOwnPassword;
@@ -63,7 +65,7 @@ public class AuthenticationBannerPresenter extends AbstractZonePresenter<Authent
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(AuthenticationBannerView.class)
+	
 	public static interface View extends ViewInterface {
 
 		Panel getNamePanel();
@@ -78,9 +80,9 @@ public class AuthenticationBannerPresenter extends AbstractZonePresenter<Authent
 
 	}
 
-	@Inject
-	public AuthenticationBannerPresenter(View view, Injector injector) {
-		super(view, injector);
+	
+	public AuthenticationBannerPresenter(View view, ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/zone/MenuBannerPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/zone/MenuBannerPresenter.java
@@ -27,6 +27,7 @@ import com.allen_sauer.gwt.log.client.Log;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.event.UpdateEvent;
 import org.sigmah.client.event.handler.UpdateHandler;
 import org.sigmah.client.i18n.I18N;
@@ -60,7 +61,7 @@ import com.google.inject.Singleton;
  * @author Tom Miette (tmiette@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class MenuBannerPresenter extends AbstractZonePresenter<MenuBannerPresenter.View> {
 
 	/**
@@ -74,7 +75,7 @@ public class MenuBannerPresenter extends AbstractZonePresenter<MenuBannerPresent
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(MenuBannerView.class)
+
 	public static interface View extends ViewInterface {
 
 		Panel getMenuPanel();
@@ -94,9 +95,8 @@ public class MenuBannerPresenter extends AbstractZonePresenter<MenuBannerPresent
 	// Page requests linked to the tabs.
 	private HashMap<TabId, PageRequest> requests;
 
-	@Inject
-	public MenuBannerPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public MenuBannerPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/presenter/zone/MessageBannerPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/zone/MessageBannerPresenter.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.presenter.zone;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -42,13 +44,11 @@ import com.google.inject.Singleton;
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
 public class MessageBannerPresenter extends AbstractZonePresenter<MessageBannerPresenter.View> {
 
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(MessageBannerView.class)
 	public static interface View extends ViewInterface {
 
 		Panel getMessagePanel();
@@ -57,8 +57,8 @@ public class MessageBannerPresenter extends AbstractZonePresenter<MessageBannerP
 
 	}
 
-	@Inject
-	public MessageBannerPresenter(View view, Injector injector) {
+
+	public MessageBannerPresenter(View view, ClientFactory injector) {
 		super(view, injector);
 	}
 

--- a/src/main/java/org/sigmah/client/ui/presenter/zone/OfflineBannerPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/zone/OfflineBannerPresenter.java
@@ -81,6 +81,8 @@ import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.i18n.shared.DateTimeFormat;
 import com.google.gwt.user.client.ui.Image;
 import java.util.List;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.ui.res.icon.offline.OfflineIconBundle;
 import org.sigmah.client.util.profiler.Execution;
@@ -98,7 +100,7 @@ import org.sigmah.shared.util.ProfileUtils;
  * @author Tom Miette (tmiette@ideia.fr)
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class OfflineBannerPresenter extends AbstractZonePresenter<OfflineBannerPresenter.View> 
 implements OfflineEvent.Source {
 	
@@ -125,7 +127,6 @@ implements OfflineEvent.Source {
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(OfflineBannerView.class)
 	public static interface View extends ViewInterface {
 
 		Panel getTraceHandle();		
@@ -143,8 +144,8 @@ implements OfflineEvent.Source {
 		public Image getTraceModeIcon();
 	}
     
-	@Inject
-	public OfflineBannerPresenter(View view, Injector injector, TransfertManager transfertManager) {
+
+	public OfflineBannerPresenter(View view, ClientFactory injector, TransfertManager transfertManager) {
 		super(view, injector);
 	}
     
@@ -165,7 +166,7 @@ implements OfflineEvent.Source {
 		ApplicationCacheManager.addHandler(createApplicationCacheEventHandler());
         
         // File transfer progress
-		final TransfertManager transfertManager = injector.getTransfertManager();
+		final TransfertManager transfertManager = factory.getTransfertManager();
         if(transfertManager instanceof HasProgressListeners) {
             ((HasProgressListeners)transfertManager).setProgressListener(TransfertType.DOWNLOAD, createProgressAdapter(ProgressType.DOWNLOAD));
             ((HasProgressListeners)transfertManager).setProgressListener(TransfertType.UPLOAD, createProgressAdapter(ProgressType.UPLOAD));
@@ -468,7 +469,7 @@ implements OfflineEvent.Source {
     }
 	
 	private int getPendingTransfers(ProgressType type) {
-		final HasProgressListeners hasProgressListeners = (HasProgressListeners) injector.getTransfertManager();
+		final HasProgressListeners hasProgressListeners = (HasProgressListeners) factory.getTransfertManager();
 		switch(type) {
 			case DOWNLOAD:
 				return hasProgressListeners.getDownloadQueueSize();
@@ -624,7 +625,7 @@ implements OfflineEvent.Source {
         view.getSynchronizePopup().setTask(I18N.CONSTANTS.offlineSynchronizePush());
         view.getSynchronizePopup().center();
         
-        injector.getSynchronizer().push(new AsyncCallback<Void>() {
+        factory.getSynchronizer().push(new AsyncCallback<Void>() {
 
             @Override
             public void onFailure(Throwable caught) {
@@ -647,7 +648,7 @@ implements OfflineEvent.Source {
                 view.getSynchronizePopup().setTask(I18N.CONSTANTS.offlineSynchronizePull());
                 progresses.put(ProgressType.DATABASE, PUSH_VALUE);
 
-                injector.getSynchronizer().pull(new SynchroProgressListener() {
+                factory.getSynchronizer().pull(new SynchroProgressListener() {
 
                     @Override
                     public void onProgress(double progress) {
@@ -666,7 +667,7 @@ implements OfflineEvent.Source {
                         setDatabaseUpdateDate(new Date());
 						
 						// Refresh the current page.
-						eventBus.navigateRequest(injector.getPageManager().getCurrentPageRequest());
+						eventBus.navigateRequest(factory.getPageManager().getCurrentPageRequest());
 						
 						pullFilesInvite();
                     }
@@ -691,7 +692,7 @@ implements OfflineEvent.Source {
         progresses.put(ProgressType.DATABASE, 0.0);
         view.setWarningIconVisible(false);
         
-        injector.getSynchronizer().pull(new SynchroProgressListener() {
+        factory.getSynchronizer().pull(new SynchroProgressListener() {
 
             @Override
             public void onProgress(double progress) {

--- a/src/main/java/org/sigmah/client/ui/presenter/zone/OrganizationBannerPresenter.java
+++ b/src/main/java/org/sigmah/client/ui/presenter/zone/OrganizationBannerPresenter.java
@@ -1,30 +1,8 @@
 package org.sigmah.client.ui.presenter.zone;
 
-/*
- * #%L
- * Sigmah
- * %%
- * Copyright (C) 2010 - 2016 URD
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-3.0.html>.
- * #L%
- */
-
-
-import org.sigmah.client.inject.Injector;
-import org.sigmah.client.page.RequestParameter;
+import org.sigmah.client.ClientFactory;
+import org.sigmah.client.event.OfflineEvent;
+import org.sigmah.client.event.handler.OfflineHandler;
 import org.sigmah.client.ui.presenter.base.AbstractZonePresenter;
 import org.sigmah.client.ui.res.ResourcesUtils;
 import org.sigmah.client.ui.view.base.ViewInterface;
@@ -33,36 +11,25 @@ import org.sigmah.client.ui.zone.Zone;
 import org.sigmah.client.ui.zone.ZoneRequest;
 import org.sigmah.client.util.ClientUtils;
 import org.sigmah.client.util.ImageProvider;
-import org.sigmah.shared.servlet.ServletConstants.Servlet;
-import org.sigmah.shared.servlet.ServletConstants.ServletMethod;
-import org.sigmah.shared.servlet.ServletRequestBuilder;
+import org.sigmah.offline.dao.LogoAsyncDAO;
+import org.sigmah.offline.status.ApplicationState;
 
-import com.google.gwt.http.client.Request;
-import com.google.gwt.http.client.RequestBuilder;
-import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasHTML;
 import com.google.gwt.user.client.ui.Panel;
-import com.google.inject.ImplementedBy;
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
-import org.sigmah.client.event.OfflineEvent;
-import org.sigmah.client.event.handler.OfflineHandler;
-import org.sigmah.offline.dao.LogoAsyncDAO;
-import org.sigmah.offline.status.ApplicationState;
 
 /**
  * Organization banner presenter displaying organization's name and logo.
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class OrganizationBannerPresenter extends AbstractZonePresenter<OrganizationBannerPresenter.View> {
 
 	/**
 	 * View interface.
 	 */
-	@ImplementedBy(OrganizationBannerView.class)
+	
 	public static interface View extends ViewInterface {
 
 		Panel getLogoPanel();
@@ -89,8 +56,8 @@ public class OrganizationBannerPresenter extends AbstractZonePresenter<Organizat
 	 */
 	private static final String DEFAULT_ORGANIZATION_LOGO = ResourcesUtils.buildImageURL("header/org-default-logo.png");
 	
-	@Inject
-	public OrganizationBannerPresenter(View view, Injector injector, LogoAsyncDAO logoAsyncDAO, ImageProvider imageProvider) {
+	
+	public OrganizationBannerPresenter(View view, ClientFactory injector, LogoAsyncDAO logoAsyncDAO, ImageProvider imageProvider) {
 		super(view, injector);
 
 		this.logoAsyncDAO = logoAsyncDAO;

--- a/src/main/java/org/sigmah/client/ui/view/ApplicationView.java
+++ b/src/main/java/org/sigmah/client/ui/view/ApplicationView.java
@@ -68,7 +68,7 @@ import com.google.inject.Singleton;
  * @author Claire Yang (cyang@ideia.fr)
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class ApplicationView implements ApplicationPresenter.View, HasPageMessage {
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/view/CreateProjectView.java
+++ b/src/main/java/org/sigmah/client/ui/view/CreateProjectView.java
@@ -67,7 +67,6 @@ import com.google.inject.Singleton;
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
 public class CreateProjectView extends AbstractPopupView<PopupWidget> implements CreateProjectPresenter.View {
 
 	// CSS.

--- a/src/main/java/org/sigmah/client/ui/view/CreditsView.java
+++ b/src/main/java/org/sigmah/client/ui/view/CreditsView.java
@@ -42,7 +42,7 @@ import com.google.inject.Singleton;
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class CreditsView extends AbstractPopupView<PopupWidget> implements CreditsPresenter.View {
 
 	// CSS.

--- a/src/main/java/org/sigmah/client/ui/view/DashboardView.java
+++ b/src/main/java/org/sigmah/client/ui/view/DashboardView.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.ui.presenter.DashboardPresenter;
 import org.sigmah.client.ui.presenter.contact.dashboardlist.ContactsListWidget;
@@ -78,7 +79,7 @@ import org.sigmah.client.ui.presenter.DashboardPresenter.ReminderOrMonitoredPoin
  * @author Tom Miette (tmiette@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class DashboardView extends AbstractView implements DashboardPresenter.View {
 
 	/**
@@ -86,11 +87,9 @@ public class DashboardView extends AbstractView implements DashboardPresenter.Vi
 	 */
 	private static final String EXPECTED_DATE_LABEL_STYLE = "points-date-exceeded";
 
-	@Inject
-	private Provider<ContactsListWidget> contactsListWidgetProvider;
-
-	@Inject
-	private Provider<ProjectsListWidget> projectsListWidgetProvider;
+	
+	
+	private ClientFactory factory;
 
 	private ContentPanel remindersPanel;
 	private ListStore<ReminderDTO> remindersStore;
@@ -119,6 +118,11 @@ public class DashboardView extends AbstractView implements DashboardPresenter.Vi
 	@Override
 	public void setReminderOrMonitoredPointHandler(final ReminderOrMonitoredPointHandler handler) {
 		this.handler = handler;
+	}
+	
+	
+	public DashboardView(ClientFactory factory) {
+		this.factory = factory;
 	}
     
     
@@ -362,7 +366,7 @@ public class DashboardView extends AbstractView implements DashboardPresenter.Vi
 	 */
 	private Widget createContactsPanel() {
 
-		contactsListWidget = contactsListWidgetProvider.get();
+		contactsListWidget = factory.getContactsListWidget();
 		contactsListWidget.initialize();
 
 		return contactsListWidget.getView().asWidget();
@@ -375,7 +379,7 @@ public class DashboardView extends AbstractView implements DashboardPresenter.Vi
 	 */
 	private Widget createProjectsPanel() {
 
-		projectsListWidget = projectsListWidgetProvider.get();
+		projectsListWidget = factory.getProjectsListWidget();
 		projectsListWidget.initialize();
 
 		return projectsListWidget.getView().asWidget();

--- a/src/main/java/org/sigmah/client/ui/view/HelpView.java
+++ b/src/main/java/org/sigmah/client/ui/view/HelpView.java
@@ -37,7 +37,7 @@ import com.google.inject.Singleton;
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
+
 public class HelpView extends AbstractPopupView<PopupWidget> implements HelpPresenter.View {
 
 	// CSS.

--- a/src/main/java/org/sigmah/client/ui/view/LoginView.java
+++ b/src/main/java/org/sigmah/client/ui/view/LoginView.java
@@ -49,7 +49,7 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class LoginView extends AbstractView implements LoginPresenter.View {
 
 	// CSS.

--- a/src/main/java/org/sigmah/client/ui/view/MockUpView.java
+++ b/src/main/java/org/sigmah/client/ui/view/MockUpView.java
@@ -36,7 +36,6 @@ import com.google.inject.Singleton;
  * 
  * @author Tom Miette (tmiette@ideia.fr)
  */
-@Singleton
 public class MockUpView extends AbstractView implements MockUpPresenter.View {
 
 	// CSS.

--- a/src/main/java/org/sigmah/client/ui/view/admin/AdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/AdminView.java
@@ -44,7 +44,6 @@ import com.google.inject.Singleton;
  * @author Maxime Lombard (mlombard@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class AdminView extends AbstractView implements AdminPresenter.View {
 
 	private SubMenuWidget subMenu;

--- a/src/main/java/org/sigmah/client/ui/view/admin/CategoriesAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/CategoriesAdminView.java
@@ -67,7 +67,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class CategoriesAdminView extends AbstractView implements CategoriesAdminPresenter.View {
 
 	private static final Float CATEGORIE_PANEL_WIDTH = 450f;

--- a/src/main/java/org/sigmah/client/ui/view/admin/ParametersAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/ParametersAdminView.java
@@ -71,7 +71,6 @@ import org.sigmah.shared.dto.password.ExpirationPolicy;
  * @author Maxime Lombard (mlombard@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ParametersAdminView extends AbstractView implements ParametersAdminPresenter.View {
 
 	// CSS styles.

--- a/src/main/java/org/sigmah/client/ui/view/admin/ReportModelsAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/ReportModelsAdminView.java
@@ -72,7 +72,6 @@ import com.google.inject.Singleton;
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class ReportModelsAdminView extends AbstractView implements ReportModelsAdminPresenter.View {
 
 	private Grid<ReportModelDTO> reportModelsGrid;

--- a/src/main/java/org/sigmah/client/ui/view/admin/importation/AddImportationSchemeView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/importation/AddImportationSchemeView.java
@@ -46,7 +46,6 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class AddImportationSchemeView extends AbstractPopupView<PopupWidget> implements AddImportationSchemePresenter.View {
 
 	private TextField<String> nameField;

--- a/src/main/java/org/sigmah/client/ui/view/admin/importation/AddVariableImporationSchemeView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/importation/AddVariableImporationSchemeView.java
@@ -39,7 +39,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
 
-@Singleton
 public class AddVariableImporationSchemeView extends AbstractPopupView<PopupWidget> implements AddVariableImporationSchemePresenter.View {
 
 	private TextField<String> nameField;

--- a/src/main/java/org/sigmah/client/ui/view/admin/importation/ImportationSchemeAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/importation/ImportationSchemeAdminView.java
@@ -78,7 +78,6 @@ import org.sigmah.client.ui.widget.panel.Panels;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ImportationSchemeAdminView extends AbstractView implements ImportationSchemeAdminPresenter.View {
 
 	// CSS style names.

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/AddBudgetSubFieldView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/AddBudgetSubFieldView.java
@@ -36,7 +36,6 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class AddBudgetSubFieldView extends AbstractPopupView<PopupWidget> implements AddBudgetSubFieldPresenter.View {
 
 	private TextField<String> nameField;

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/EditFlexibleElementAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/EditFlexibleElementAdminView.java
@@ -90,7 +90,6 @@ import org.sigmah.shared.dto.report.ReportModelDTO;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class EditFlexibleElementAdminView extends AbstractPopupView<PopupWidget> implements EditFlexibleElementAdminPresenter.View {
 
 	// CSS style names.

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/EditLayoutGroupAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/EditLayoutGroupAdminView.java
@@ -46,7 +46,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class EditLayoutGroupAdminView extends AbstractPopupView<PopupWidget> implements EditLayoutGroupAdminPresenter.View {
 
 	private FormPanel form;

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/contact/AddContactModelAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/contact/AddContactModelAdminView.java
@@ -38,7 +38,6 @@ import org.sigmah.client.ui.widget.form.Forms;
 import org.sigmah.client.ui.widget.popup.PopupWidget;
 import org.sigmah.shared.dto.referential.ContactModelType;
 
-@Singleton
 public class AddContactModelAdminView extends AbstractPopupView<PopupWidget> implements AddContactModelAdminPresenter.View {
 
 	private FormPanel form;

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/importer/AddImportationSchemeModelsAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/importer/AddImportationSchemeModelsAdminView.java
@@ -43,7 +43,7 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
 
-@Singleton
+
 public class AddImportationSchemeModelsAdminView extends AbstractPopupView<PopupWidget> implements AddImportationSchemeModelsAdminPresenter.View {
 
 	private FormPanel mainPanel;
@@ -51,8 +51,8 @@ public class AddImportationSchemeModelsAdminView extends AbstractPopupView<Popup
 	private Button submitButton;
 	private ListStore<ImportationSchemeDTO> schemasStore;
 
-	@Inject
-	protected AddImportationSchemeModelsAdminView() {
+	
+	public AddImportationSchemeModelsAdminView() {
 		super(new PopupWidget(true), 500);
 	}
 

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/importer/AddMatchingRuleImportationShemeModelsAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/importer/AddMatchingRuleImportationShemeModelsAdminView.java
@@ -45,7 +45,7 @@ import org.sigmah.client.ui.widget.form.FormPanel;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
+
 public class AddMatchingRuleImportationShemeModelsAdminView extends AbstractPopupView<PopupWidget> implements
 																																																	AddMatchingRuleImportationShemeModelsAdminPresenter.View {
 
@@ -58,8 +58,7 @@ public class AddMatchingRuleImportationShemeModelsAdminView extends AbstractPopu
 
 	private FormPanel mainPanel;
 
-	@Inject
-	protected AddMatchingRuleImportationShemeModelsAdminView() {
+	public AddMatchingRuleImportationShemeModelsAdminView() {
 		super(new PopupWidget(true), 500);
 	}
 

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/importer/ImportModelView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/importer/ImportModelView.java
@@ -44,7 +44,7 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)V2.0
  */
-@Singleton
+
 public class ImportModelView extends AbstractPopupView<PopupWidget> implements ImportModelPresenter.View {
 
 	private Button importButton;

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/orgunit/AddOrgUnitModelAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/orgunit/AddOrgUnitModelAdminView.java
@@ -42,7 +42,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class AddOrgUnitModelAdminView extends AbstractPopupView<PopupWidget> implements AddOrgUnitModelAdminPresenter.View {
 
 	private FormPanel form;

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/orgunit/OrgUnitModelsAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/orgunit/OrgUnitModelsAdminView.java
@@ -44,7 +44,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class OrgUnitModelsAdminView extends AbstractModelsAdminView<OrgUnitModelDTO> implements OrgUnitModelsAdminPresenter.View {
 
 	private TextField<String> nameField;

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/project/AddProjectModelAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/project/AddProjectModelAdminView.java
@@ -43,7 +43,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class AddProjectModelAdminView extends AbstractPopupView<PopupWidget> implements AddProjectModelAdminPresenter.View {
 
 	private FormPanel form;

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/project/EditPhaseModelAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/project/EditPhaseModelAdminView.java
@@ -52,7 +52,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class EditPhaseModelAdminView extends AbstractPopupView<PopupWidget> implements EditPhaseModelAdminPresenter.View {
 
 	private Map<CheckBox, PhaseModelDTO> successors;

--- a/src/main/java/org/sigmah/client/ui/view/admin/models/project/ProjectModelsAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/models/project/ProjectModelsAdminView.java
@@ -53,7 +53,6 @@ import org.sigmah.shared.dto.referential.ProjectModelType;
  *
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class ProjectModelsAdminView extends AbstractModelsAdminView<ProjectModelDTO> implements ProjectModelsAdminPresenter.View {
 
 	private TextField<String> nameField;

--- a/src/main/java/org/sigmah/client/ui/view/admin/orgunits/AddOrgUnitAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/orgunits/AddOrgUnitAdminView.java
@@ -47,7 +47,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class AddOrgUnitAdminView extends AbstractPopupView<PopupWidget> implements AddOrgUnitAdminPresenter.View {
 
 	private FormPanel form;

--- a/src/main/java/org/sigmah/client/ui/view/admin/orgunits/MoveOrgUnitAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/orgunits/MoveOrgUnitAdminView.java
@@ -43,7 +43,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class MoveOrgUnitAdminView extends AbstractPopupView<PopupWidget> implements MoveOrgUnitAdminPresenter.View {
 
 	private FormPanel form;

--- a/src/main/java/org/sigmah/client/ui/view/admin/orgunits/OrgUnitsAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/orgunits/OrgUnitsAdminView.java
@@ -72,7 +72,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class OrgUnitsAdminView extends AbstractView implements OrgUnitsAdminPresenter.View {
 
 	// CSS style names.

--- a/src/main/java/org/sigmah/client/ui/view/admin/users/PrivacyGroupEditView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/users/PrivacyGroupEditView.java
@@ -42,7 +42,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class PrivacyGroupEditView extends AbstractPopupView<PopupWidget> implements PrivacyGroupEditPresenter.View {
 
 	private FormPanel formPanel;

--- a/src/main/java/org/sigmah/client/ui/view/admin/users/ProfileEditView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/users/ProfileEditView.java
@@ -55,7 +55,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class ProfileEditView extends AbstractPopupView<PopupWidget> implements ProfileEditPresenter.View {
 
 	private FormPanel formPanel;
@@ -68,7 +67,7 @@ public class ProfileEditView extends AbstractPopupView<PopupWidget> implements P
 	/**
 	 * View popup initialization.
 	 */
-	protected ProfileEditView() {
+	public ProfileEditView() {
 		super(new PopupWidget(true));
 		popup.setWidth(null); // Enables auto-width.
 	}

--- a/src/main/java/org/sigmah/client/ui/view/admin/users/UserEditView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/users/UserEditView.java
@@ -82,7 +82,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) v2.0
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class UserEditView extends AbstractPopupView<PopupWidget> implements UserEditPresenter.View {
 
 	// CSS style names.

--- a/src/main/java/org/sigmah/client/ui/view/admin/users/UsersAdminView.java
+++ b/src/main/java/org/sigmah/client/ui/view/admin/users/UsersAdminView.java
@@ -87,7 +87,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) v2.0
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class UsersAdminView extends AbstractView implements UsersAdminPresenter.View {
 
 	// CSS style names.

--- a/src/main/java/org/sigmah/client/ui/view/calendar/CalendarEventView.java
+++ b/src/main/java/org/sigmah/client/ui/view/calendar/CalendarEventView.java
@@ -44,7 +44,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class CalendarEventView extends AbstractPopupView<PopupWidget> implements CalendarEventPresenter.View {
 
 	private FormPanel form;

--- a/src/main/java/org/sigmah/client/ui/view/contact/export/ExportContactsSettingView.java
+++ b/src/main/java/org/sigmah/client/ui/view/contact/export/ExportContactsSettingView.java
@@ -68,7 +68,7 @@ import org.sigmah.shared.dto.layout.LayoutGroupDTO;
 import org.sigmah.shared.dto.referential.DefaultContactFlexibleElementType;
 import org.sigmah.shared.dto.referential.ElementTypeEnum;
 
-@Singleton
+
 public class ExportContactsSettingView extends AbstractPopupView<PopupWidget> implements ExportContactsSettingPresenter.View {
 
 	private FormPanel panel;

--- a/src/main/java/org/sigmah/client/ui/view/contact/export/ExportContactsView.java
+++ b/src/main/java/org/sigmah/client/ui/view/contact/export/ExportContactsView.java
@@ -51,7 +51,7 @@ import org.sigmah.client.util.DateUtils;
 import org.sigmah.shared.dto.GlobalContactExportDTO;
 import org.sigmah.shared.dto.GlobalExportDTO;
 
-@Singleton
+
 public class ExportContactsView extends AbstractPopupView<PopupWidget> implements ExportContactsPresenter.View {
 
 	private Button settingsButton;

--- a/src/main/java/org/sigmah/client/ui/view/orgunit/OrgUnitCalendarView.java
+++ b/src/main/java/org/sigmah/client/ui/view/orgunit/OrgUnitCalendarView.java
@@ -34,7 +34,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class OrgUnitCalendarView extends AbstractView implements OrgUnitCalendarPresenter.View {
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/view/orgunit/OrgUnitDashboardView.java
+++ b/src/main/java/org/sigmah/client/ui/view/orgunit/OrgUnitDashboardView.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.view.orgunit;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -45,15 +47,18 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
 
-@Singleton
 public class OrgUnitDashboardView extends AbstractView implements OrgUnitDashboardPresenter.View {
 
-	@Inject
-	private Provider<ProjectsListWidget> projectsListWidgetProvider;
+	
+	ClientFactory factory;
 
 	private OrgUnitTreeGrid tree;
 	private ContentPanel contentPanelOrgUnit;
 	private ProjectsListWidget projectsListWidget;
+	
+	public OrgUnitDashboardView(ClientFactory factory) {
+		this.factory = factory;
+	}
 
 	@Override
 	public void initialize() {
@@ -107,7 +112,7 @@ public class OrgUnitDashboardView extends AbstractView implements OrgUnitDashboa
 	 */
 	private Widget createProjectsPanel() {
 
-		projectsListWidget = projectsListWidgetProvider.get();
+		projectsListWidget = factory.getProjectsListWidget();
 		projectsListWidget.initialize();
 
 		return projectsListWidget.getView().asWidget();

--- a/src/main/java/org/sigmah/client/ui/view/orgunit/OrgUnitDetailsView.java
+++ b/src/main/java/org/sigmah/client/ui/view/orgunit/OrgUnitDetailsView.java
@@ -50,7 +50,6 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr) (v2.0)
  * @author Denis Colliot (dcolliot@ideia.fr) (v2.0)
  */
-@Singleton
 public class OrgUnitDetailsView extends AbstractView implements OrgUnitDetailsPresenter.View {
 
 	private ContentPanel contentOrgUnitDetailsPanel;

--- a/src/main/java/org/sigmah/client/ui/view/orgunit/OrgUnitReportsView.java
+++ b/src/main/java/org/sigmah/client/ui/view/orgunit/OrgUnitReportsView.java
@@ -32,7 +32,7 @@ import com.google.inject.Singleton;
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
 
-@Singleton
+
 public class OrgUnitReportsView extends AbstractView implements OrgUnitReportsPresenter.View {
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/view/orgunit/OrgUnitView.java
+++ b/src/main/java/org/sigmah/client/ui/view/orgunit/OrgUnitView.java
@@ -52,7 +52,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class OrgUnitView extends AbstractView implements OrgUnitPresenter.View {
 
 	// Grids coordinates.

--- a/src/main/java/org/sigmah/client/ui/view/password/ChangeOwnPasswordView.java
+++ b/src/main/java/org/sigmah/client/ui/view/password/ChangeOwnPasswordView.java
@@ -39,7 +39,6 @@ import org.sigmah.client.ui.widget.popup.PopupWidget;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ChangeOwnPasswordView extends AbstractPopupView<PopupWidget> implements ChangeOwnPasswordPresenter.View {
 
 	private FormPanel formPanel;

--- a/src/main/java/org/sigmah/client/ui/view/password/LostPasswordView.java
+++ b/src/main/java/org/sigmah/client/ui/view/password/LostPasswordView.java
@@ -40,7 +40,7 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class LostPasswordView extends AbstractPopupView<PopupWidget> implements LostPasswordPresenter.View {
 
 	private FormPanel formPanel;

--- a/src/main/java/org/sigmah/client/ui/view/password/ResetPasswordView.java
+++ b/src/main/java/org/sigmah/client/ui/view/password/ResetPasswordView.java
@@ -44,7 +44,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ResetPasswordView extends AbstractView implements ResetPasswordPresenter.View {
 
 	private TextBox emailTextBox;

--- a/src/main/java/org/sigmah/client/ui/view/pivot/ProjectPivotContainer.java
+++ b/src/main/java/org/sigmah/client/ui/view/pivot/ProjectPivotContainer.java
@@ -128,7 +128,7 @@ public class ProjectPivotContainer extends ContentPanel implements Loadable {
 	private PivotLayout currentLayout;
 	private PivotTableElement currentPivot;
 	
-	@Inject
+	
 	public ProjectPivotContainer(EventBus eventBus, DispatchAsync dispatcher, PivotGridPanel gridPanel, IStateManager stateManager) {
 		this.dispatcher = dispatcher;
 		this.eventBus = eventBus;

--- a/src/main/java/org/sigmah/client/ui/view/pivot/table/PivotGridPanel.java
+++ b/src/main/java/org/sigmah/client/ui/view/pivot/table/PivotGridPanel.java
@@ -97,7 +97,7 @@ public class PivotGridPanel extends ContentPanel implements HasValue<PivotElemen
 	
 	private boolean loading;
 
-	@Inject
+	
 	public PivotGridPanel(EventBus eventBus, DispatchAsync dispatcher) {
 		this.eventBus = eventBus;
 		this.dispatcher = dispatcher;

--- a/src/main/java/org/sigmah/client/ui/view/pivot/table/drilldown/DrillDownEditor.java
+++ b/src/main/java/org/sigmah/client/ui/view/pivot/table/drilldown/DrillDownEditor.java
@@ -28,6 +28,7 @@ package org.sigmah.client.ui.view.pivot.table.drilldown;
  */
 
 import org.sigmah.client.i18n.I18N;
+import org.sigmah.client.security.AuthenticationProvider;
 import org.sigmah.client.dispatch.DispatchAsync;
 import org.sigmah.client.event.EventBus;
 import org.sigmah.client.ui.view.project.indicator.SiteGridPanel;
@@ -48,7 +49,8 @@ public class DrillDownEditor extends SiteGridPanel {
 
     private final Dates dates;
 
-    public DrillDownEditor(EventBus eventBus, DispatchAsync service, IStateManager stateMgr, Dates dates) {
+    public DrillDownEditor(EventBus eventBus, DispatchAsync service, IStateManager stateMgr, AuthenticationProvider authenticationProvider, Dates dates) {
+    	super(eventBus, service, authenticationProvider);
     	this.dates = dates;
 
     	setHeadingText(I18N.CONSTANTS.drilldown());

--- a/src/main/java/org/sigmah/client/ui/view/project/LinkedProjectView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/LinkedProjectView.java
@@ -53,7 +53,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class LinkedProjectView extends AbstractPopupView<PopupWidget> implements LinkedProjectPresenter.View {
 
 	// CSS style names.

--- a/src/main/java/org/sigmah/client/ui/view/project/ProjectCalendarView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/ProjectCalendarView.java
@@ -33,7 +33,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ProjectCalendarView extends AbstractView implements ProjectCalendarPresenter.View {
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/view/project/ProjectDetailsView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/ProjectDetailsView.java
@@ -49,7 +49,7 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class ProjectDetailsView extends AbstractView implements ProjectDetailsPresenter.View {
 
 	private ContentPanel mainPanel;

--- a/src/main/java/org/sigmah/client/ui/view/project/ProjectReportsView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/ProjectReportsView.java
@@ -33,7 +33,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ProjectReportsView extends AbstractView implements ProjectReportsPresenter.View {
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/view/project/ProjectView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/ProjectView.java
@@ -83,7 +83,6 @@ import org.sigmah.shared.dto.referential.CoreVersionActionType;
  *
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ProjectView extends AbstractView implements ProjectPresenter.View {
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/view/project/dashboard/ProjectDashboardView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/dashboard/ProjectDashboardView.java
@@ -25,6 +25,7 @@ package org.sigmah.client.ui.view.project.dashboard;
 
 import java.util.Date;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.ui.presenter.project.dashboard.PhasesPresenter;
 import org.sigmah.client.ui.presenter.project.dashboard.ProjectDashboardPresenter;
@@ -72,14 +73,13 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class ProjectDashboardView extends AbstractView implements ProjectDashboardPresenter.View {
 
 	// CSS style names.
 	private static final String STYLE_TOOLBAR_TITLE = "toolbar-title";
 
-	@Inject
-	private Provider<PhasesPresenter> phasesPresenterProvider;
+	ClientFactory factory;
 	private PhasesPresenter phasesPresenter;
 
 	private Grid<ReminderDTO> remindersGrid;
@@ -108,6 +108,12 @@ public class ProjectDashboardView extends AbstractView implements ProjectDashboa
 	 * Specific presenter's handlers.
 	 */
 	private PresenterHandler handler;
+	
+	
+	public ProjectDashboardView(ClientFactory factory){
+		this.factory = factory;
+		
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -653,7 +659,7 @@ public class ProjectDashboardView extends AbstractView implements ProjectDashboa
 	 */
 	private Component createProjectDashboardPanel() {
 
-		phasesPresenter = phasesPresenterProvider.get();
+		phasesPresenter = factory.getPhasesPresenter();
 		phasesPresenter.initialize();
 
 		return (Component) phasesPresenter.getView().asWidget();

--- a/src/main/java/org/sigmah/client/ui/view/project/export/ExportProjectsSettingView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/export/ExportProjectsSettingView.java
@@ -72,7 +72,6 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class ExportProjectsSettingView extends AbstractPopupView<PopupWidget> implements ExportProjectsSettingPresenter.View {
 
 	private FormPanel panel;

--- a/src/main/java/org/sigmah/client/ui/view/project/export/ExportProjectsView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/export/ExportProjectsView.java
@@ -54,7 +54,6 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class ExportProjectsView extends AbstractPopupView<PopupWidget> implements ExportProjectsPresenter.View {
 
 	private Button settingsButton;

--- a/src/main/java/org/sigmah/client/ui/view/project/indicator/EditIndicatorView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/indicator/EditIndicatorView.java
@@ -31,6 +31,8 @@ import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.DispatchAsync;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.client.ui.presenter.project.indicator.EditIndicatorPresenter;
@@ -78,19 +80,20 @@ public class EditIndicatorView extends AbstractPopupView<PopupWidget> implements
 	private Button saveButton;
 	private Button cancelButton;
 	
-	@Inject
 	private PivotGridPanel pivotGridPanel;
 	private Widget pivotLabel;
 	
 	// Required by DatasourceField
-	@Inject
 	private DispatchAsync dispatchAsync;
+	
 	
 	/**
 	 * Builds the view.
 	 */
-	public EditIndicatorView() {
+	public EditIndicatorView(DispatchAsync dispatch, PivotGridPanel pivotGridPanel) {
 		super(new PopupWidget(true), 800);
+		this.dispatchAsync = dispatch;
+		this.pivotGridPanel = pivotGridPanel;
 	}
 
 	/**

--- a/src/main/java/org/sigmah/client/ui/view/project/indicator/ProjectIndicatorEntriesView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/indicator/ProjectIndicatorEntriesView.java
@@ -34,11 +34,16 @@ import org.sigmah.client.ui.view.pivot.ProjectPivotContainer;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class ProjectIndicatorEntriesView extends AbstractView implements ProjectIndicatorEntriesPresenter.View {
 
-	@Inject
+	
 	private ProjectPivotContainer projectPivotContainer;
+	
+	
+	public ProjectIndicatorEntriesView(ProjectPivotContainer projectPivotContainer) {
+		this.projectPivotContainer = projectPivotContainer;
+	}
 	
 	/**
 	 * {@inheritDoc}

--- a/src/main/java/org/sigmah/client/ui/view/project/indicator/ProjectIndicatorManagementView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/indicator/ProjectIndicatorManagementView.java
@@ -75,7 +75,6 @@ import org.sigmah.shared.dto.IndicatorGroup;
  * @author Denis Colliot (dcolliot@ideia.fr)
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ProjectIndicatorManagementView extends AbstractView implements ProjectIndicatorManagementPresenter.View {
 
 	/** Main panel. */

--- a/src/main/java/org/sigmah/client/ui/view/project/indicator/ProjectIndicatorMapView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/indicator/ProjectIndicatorMapView.java
@@ -47,10 +47,9 @@ import org.sigmah.client.ui.widget.panel.Panels;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ProjectIndicatorMapView extends AbstractView implements ProjectIndicatorMapPresenter.View {
 
-	@Inject
+	
 	private SiteGridPanel siteGridPanel;
 	
 	private ContentPanel mapDisplayPanel;
@@ -58,6 +57,11 @@ public class ProjectIndicatorMapView extends AbstractView implements ProjectIndi
 	private WorldMap worldMap;
 	
 	private Status mapStatusBar;
+	
+	
+	public ProjectIndicatorMapView(SiteGridPanel siteGridPanel) {
+		this.siteGridPanel = siteGridPanel;
+	}
 	
 	
 	/**

--- a/src/main/java/org/sigmah/client/ui/view/project/indicator/SiteGridPanel.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/indicator/SiteGridPanel.java
@@ -103,13 +103,12 @@ public class SiteGridPanel extends ContentPanel implements SelectionProvider<Sit
 
     public static final int PAGE_SIZE = 25;
 
-	@Inject
+
     private EventBus eventBus;
 	
-	@Inject
+
     private DispatchAsync service;
 	
-	@Inject
 	private AuthenticationProvider authenticationProvider;
 
     private PagingLoader<SiteResult> loader;
@@ -131,8 +130,12 @@ public class SiteGridPanel extends ContentPanel implements SelectionProvider<Sit
 	
 	private SchemaDTO schema;
 
-    public SiteGridPanel() {
+    public SiteGridPanel(EventBus eventBus, DispatchAsync service, AuthenticationProvider authenticationProvider) {
+    	
         setLayout(new FitLayout());
+        this.eventBus = eventBus;
+        this.service = service;
+        this.authenticationProvider = authenticationProvider;
         setHeadingText(I18N.CONSTANTS.sites());
         initLoader();
 

--- a/src/main/java/org/sigmah/client/ui/view/project/logframe/ProjectLogFrameGrid.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/logframe/ProjectLogFrameGrid.java
@@ -203,7 +203,7 @@ public class ProjectLogFrameGrid implements IsWidget {
 	 */
 	private FlexTableView prerequisitesView;
 
-	@Inject
+	
 	private EventBus eventBus;
 	
 	private int databaseId;
@@ -211,11 +211,12 @@ public class ProjectLogFrameGrid implements IsWidget {
 	/**
 	 * Builds an empty grid.
 	 */
-	public ProjectLogFrameGrid() {
+	public ProjectLogFrameGrid(EventBus eventBus) {
 		listeners = new ArrayList<LogFrameGridListener>();
 		table = new FlexTable();
 		formWindow = new FormWindow();
-	}
+		this.eventBus = eventBus;
+	}  
 
 	/**
 	 * Registers a listener.

--- a/src/main/java/org/sigmah/client/ui/view/project/logframe/ProjectLogFrameView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/logframe/ProjectLogFrameView.java
@@ -1,5 +1,7 @@
 package org.sigmah.client.ui.view.project.logframe;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -58,7 +60,7 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
+
 public class ProjectLogFrameView extends AbstractView implements ProjectLogFramePresenter.View {
 
 	// CSS style names.
@@ -84,8 +86,11 @@ public class ProjectLogFrameView extends AbstractView implements ProjectLogFrame
 	private TextField<String> mainObjectiveField;
 
 	// Grid.
-	@Inject
 	private ProjectLogFrameGrid logFrameGrid;
+	
+	public ProjectLogFrameView(ProjectLogFrameGrid grid) {
+		grid = logFrameGrid;
+	}
 
 	/**
 	 * {@inheritDoc}

--- a/src/main/java/org/sigmah/client/ui/view/project/projectcore/ProjectCoreDiffView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/projectcore/ProjectCoreDiffView.java
@@ -50,7 +50,6 @@ import java.util.Arrays;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-@Singleton
 public class ProjectCoreDiffView extends AbstractPopupView<PopupWidget> implements ProjectCoreDiffPresenter.View {
 
 	private ContentPanel mainPanel;

--- a/src/main/java/org/sigmah/client/ui/view/project/projectcore/ProjectCoreRenameVersionView.java
+++ b/src/main/java/org/sigmah/client/ui/view/project/projectcore/ProjectCoreRenameVersionView.java
@@ -57,8 +57,6 @@ import com.google.inject.Singleton;
 /**
  * @author Mehdi Benabdeslam (mehdi.benabdeslam@netapsys.fr)
  */
-
-@Singleton
 public class ProjectCoreRenameVersionView extends AbstractPopupView<PopupWidget> implements ProjectCoreRenameVersionPresenter.View {
 
 	private ContentPanel mainPanel;

--- a/src/main/java/org/sigmah/client/ui/view/reminder/ReminderEditView.java
+++ b/src/main/java/org/sigmah/client/ui/view/reminder/ReminderEditView.java
@@ -44,7 +44,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ReminderEditView extends AbstractPopupView<PopupWidget> implements ReminderEditPresenter.View {
 
 	// CSS style names.

--- a/src/main/java/org/sigmah/client/ui/view/reminder/ReminderHistoryView.java
+++ b/src/main/java/org/sigmah/client/ui/view/reminder/ReminderHistoryView.java
@@ -44,7 +44,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ReminderHistoryView extends AbstractPopupView<PopupWidget> implements ReminderHistoryPresenter.View {
 
 	private Grid<AbstractModelDataEntityDTO<?>> grid;

--- a/src/main/java/org/sigmah/client/ui/view/reports/AttachFileView.java
+++ b/src/main/java/org/sigmah/client/ui/view/reports/AttachFileView.java
@@ -45,7 +45,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class AttachFileView extends AbstractPopupView<PopupWidget> implements AttachFilePresenter.View {
 
 	private FormPanel uploadFormPanel;

--- a/src/main/java/org/sigmah/client/ui/view/reports/ReportCreateView.java
+++ b/src/main/java/org/sigmah/client/ui/view/reports/ReportCreateView.java
@@ -40,7 +40,6 @@ import com.google.inject.Singleton;
  * 
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ReportCreateView extends AbstractPopupView<PopupWidget> implements ReportCreatePresenter.View {
 
 	private FormPanel form;

--- a/src/main/java/org/sigmah/client/ui/widget/form/DatasourceField.java
+++ b/src/main/java/org/sigmah/client/ui/widget/form/DatasourceField.java
@@ -51,6 +51,8 @@ import com.extjs.gxt.ui.client.widget.form.CheckBox;
 import com.extjs.gxt.ui.client.widget.layout.FitLayout;
 import com.extjs.gxt.ui.client.widget.toolbar.ToolBar;
 import java.util.ArrayList;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.DispatchAsync;
 import org.sigmah.client.dispatch.monitor.LoadingMask;

--- a/src/main/java/org/sigmah/client/ui/widget/popup/IndicatorBrowsePopup.java
+++ b/src/main/java/org/sigmah/client/ui/widget/popup/IndicatorBrowsePopup.java
@@ -46,6 +46,8 @@ import com.extjs.gxt.ui.client.widget.treepanel.TreePanel.CheckNodes;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.AbstractImagePrototype;
 import com.google.inject.Inject;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.DispatchAsync;
 import org.sigmah.client.i18n.I18N;
@@ -71,7 +73,7 @@ public class IndicatorBrowsePopup extends AbstractPopupView<PopupWidget> {
 	
 	private AsyncCallback<VoidResult> callback;
 
-	@Inject
+	
 	public IndicatorBrowsePopup(DispatchAsync dispatcher) {
 		super(new PopupWidget(true));
 		

--- a/src/main/java/org/sigmah/client/util/ImageProvider.java
+++ b/src/main/java/org/sigmah/client/util/ImageProvider.java
@@ -28,6 +28,7 @@ import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.inject.Injector;
 import org.sigmah.client.page.RequestParameter;
 import org.sigmah.shared.servlet.ServletConstants;
@@ -38,17 +39,17 @@ import org.sigmah.shared.servlet.ServletRequestBuilder;
  */
 
 public class ImageProvider {
-  private final Injector injector;
+  private final ClientFactory factory;
 
-  @Inject
-  public ImageProvider(Injector injector) {
-    this.injector = injector;
+  
+  public ImageProvider(ClientFactory factory) {
+    this.factory = factory;
   }
 
   // TODO: Create a servlet which return the image stream, not a Byte64 string which is very heavy
 
   public void provideDataUrl(final String imageId, final AsyncCallback<String> callback) {
-    ServletRequestBuilder builder = new ServletRequestBuilder(injector, RequestBuilder.GET, ServletConstants.Servlet.FILE, ServletConstants.ServletMethod.DOWNLOAD_LOGO);
+    ServletRequestBuilder builder = new ServletRequestBuilder(factory, RequestBuilder.GET, ServletConstants.Servlet.FILE, ServletConstants.ServletMethod.DOWNLOAD_LOGO);
     builder.addParameter(RequestParameter.ID, imageId);
     builder.send(new ServletRequestBuilder.RequestCallbackAdapter() {
       @Override

--- a/src/main/java/org/sigmah/offline/dao/AuthenticationAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/AuthenticationAsyncDAO.java
@@ -33,7 +33,6 @@ import org.sigmah.shared.command.result.Authentication;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class AuthenticationAsyncDAO extends AbstractUserDatabaseAsyncDAO<Authentication, AuthenticationJS> {
 	
 	public void get(AsyncCallback<Authentication> callback) {

--- a/src/main/java/org/sigmah/offline/dao/BaseAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/BaseAsyncDAO.java
@@ -44,7 +44,7 @@ import org.sigmah.offline.indexeddb.Schema;
  */
 public abstract class BaseAsyncDAO<S extends Enum<S> & Schema> {
 	
-	@Inject
+	
 	private AuthenticationProvider authenticationProvider;
 	
 	/**

--- a/src/main/java/org/sigmah/offline/dao/CategoryElementAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/CategoryElementAsyncDAO.java
@@ -35,7 +35,6 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class CategoryElementAsyncDAO extends AbstractUserDatabaseAsyncDAO<CategoryElementDTO, CategoryElementJS> {
 
 	/**

--- a/src/main/java/org/sigmah/offline/dao/CategoryTypeAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/CategoryTypeAsyncDAO.java
@@ -46,12 +46,10 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class CategoryTypeAsyncDAO extends AbstractUserDatabaseAsyncDAO<CategoryTypeDTO, CategoryTypeJS> {
 	
 	private final CategoryElementAsyncDAO categoryElementAsyncDAO;
 
-	@Inject
 	public CategoryTypeAsyncDAO(CategoryElementAsyncDAO categoryElementAsyncDAO) {
 		this.categoryElementAsyncDAO = categoryElementAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/dao/CountryAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/CountryAsyncDAO.java
@@ -33,7 +33,6 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class CountryAsyncDAO extends AbstractUserDatabaseAsyncDAO<CountryDTO, CountryJS> {
 	
 	/**

--- a/src/main/java/org/sigmah/offline/dao/FileDataAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/FileDataAsyncDAO.java
@@ -40,7 +40,7 @@ import org.sigmah.offline.js.FileDataJS;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class FileDataAsyncDAO extends AbstractAsyncDAO<FileDataJS, Store> {
 
 	/**

--- a/src/main/java/org/sigmah/offline/dao/HistoryAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/HistoryAsyncDAO.java
@@ -44,7 +44,6 @@ import org.sigmah.offline.indexeddb.OpenDatabaseRequest;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class HistoryAsyncDAO extends BaseAsyncDAO<Store> {
 
 	/**

--- a/src/main/java/org/sigmah/offline/dao/LogFrameAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/LogFrameAsyncDAO.java
@@ -33,7 +33,6 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class LogFrameAsyncDAO extends AbstractUserDatabaseAsyncDAO<LogFrameDTO, LogFrameJS> {
 
 	/**

--- a/src/main/java/org/sigmah/offline/dao/MonitoredPointAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/MonitoredPointAsyncDAO.java
@@ -45,7 +45,7 @@ import org.sigmah.offline.indexeddb.Index;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class MonitoredPointAsyncDAO extends AbstractUserDatabaseAsyncDAO<MonitoredPointDTO, MonitoredPointJS> {
 
 	public void saveOrUpdate(final MonitoredPointListDTO monitoredPointListDTO, Transaction<Store> transaction) {

--- a/src/main/java/org/sigmah/offline/dao/OrgUnitAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/OrgUnitAsyncDAO.java
@@ -52,13 +52,12 @@ import com.allen_sauer.gwt.log.client.Log;
  *
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class OrgUnitAsyncDAO extends AbstractUserDatabaseAsyncDAO<OrgUnitDTO, OrgUnitJS> {
 
 	private final OrgUnitModelAsyncDAO orgUnitModelAsyncDAO;
 	private final CountryAsyncDAO countryAsyncDAO;
 
-	@Inject
+	
 	public OrgUnitAsyncDAO(OrgUnitModelAsyncDAO orgUnitModelAsyncDAO, CountryAsyncDAO countryAsyncDAO) {
 		this.orgUnitModelAsyncDAO = orgUnitModelAsyncDAO;
 		this.countryAsyncDAO = countryAsyncDAO;

--- a/src/main/java/org/sigmah/offline/dao/OrgUnitModelAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/OrgUnitModelAsyncDAO.java
@@ -33,7 +33,7 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class OrgUnitModelAsyncDAO extends AbstractUserDatabaseAsyncDAO<OrgUnitModelDTO, OrgUnitModelJS> {
 
 	/**

--- a/src/main/java/org/sigmah/offline/dao/OrganizationAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/OrganizationAsyncDAO.java
@@ -42,12 +42,11 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class OrganizationAsyncDAO extends AbstractUserDatabaseAsyncDAO<OrganizationDTO, OrganizationJS> {
 	
 	private final OrgUnitAsyncDAO orgUnitDAO;
 
-	@Inject
+	
 	public OrganizationAsyncDAO(OrgUnitAsyncDAO orgUnitDAO) {
 		this.orgUnitDAO = orgUnitDAO;
 	}

--- a/src/main/java/org/sigmah/offline/dao/PageAccessAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/PageAccessAsyncDAO.java
@@ -40,7 +40,6 @@ import org.sigmah.offline.indexeddb.OpenDatabaseRequest;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class PageAccessAsyncDAO extends BaseAsyncDAO<Store> {
 
 	/**

--- a/src/main/java/org/sigmah/offline/dao/PersonalCalendarAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/PersonalCalendarAsyncDAO.java
@@ -33,7 +33,6 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class PersonalCalendarAsyncDAO extends AbstractUserDatabaseAsyncDAO<Calendar, PersonalCalendarJS> {
 
 	/**

--- a/src/main/java/org/sigmah/offline/dao/PhaseAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/PhaseAsyncDAO.java
@@ -42,7 +42,7 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class PhaseAsyncDAO extends AbstractUserDatabaseAsyncDAO<PhaseDTO, PhaseJS> {
 	
 	private final PhaseModelAsyncDAO phaseModelAsyncDAO;
@@ -50,7 +50,7 @@ public class PhaseAsyncDAO extends AbstractUserDatabaseAsyncDAO<PhaseDTO, PhaseJ
 	/**
 	 * {@inheritDoc}
 	 */
-	@Inject
+	
 	public PhaseAsyncDAO(PhaseModelAsyncDAO phaseModelAsyncDAO) {
 		this.phaseModelAsyncDAO = phaseModelAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/dao/PhaseModelAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/PhaseModelAsyncDAO.java
@@ -40,7 +40,6 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class PhaseModelAsyncDAO extends AbstractUserDatabaseAsyncDAO<PhaseModelDTO, PhaseModelJS> {
 
 	/**

--- a/src/main/java/org/sigmah/offline/dao/ProjectAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/ProjectAsyncDAO.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.offline.indexeddb.Cursor;
 import org.sigmah.offline.indexeddb.IDBKeyRange;
 import org.sigmah.offline.indexeddb.Index;
@@ -71,29 +72,34 @@ import org.sigmah.shared.util.ValueResultUtils;
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class ProjectAsyncDAO extends AbstractUserDatabaseAsyncDAO<ProjectDTO, ProjectJS> {
 	
-	@Inject
 	private ProjectModelAsyncDAO projectModelAsyncDAO;
 	
-	@Inject
 	private OrgUnitAsyncDAO orgUnitAsyncDAO;
 	
-	@Inject
 	private PhaseAsyncDAO phaseAsyncDAO;
 	
-	@Inject
 	private LogFrameAsyncDAO logFrameAsyncDAO;
 	
-	@Inject
 	private MonitoredPointAsyncDAO monitoredPointAsyncDAO;
 	
-	@Inject
 	private ReminderAsyncDAO reminderAsyncDAO;
 	
-	@Inject
 	private ValueAsyncDAO valueAsyncDAO;
+	
+	private ClientFactory factory;
+
+	public ProjectAsyncDAO(ClientFactory factory) {
+		this.factory = factory;
+		this.projectModelAsyncDAO = this.factory.getProjectModelAsyncDAO();
+		this.orgUnitAsyncDAO = this.factory.getOrgUnitAsyncDAO();
+		this.phaseAsyncDAO = this.factory.getPhaseAsyncDAO();
+		this.logFrameAsyncDAO = this.factory.getLogFrameAsyncDAO();
+		this.monitoredPointAsyncDAO = this.factory.getMonitoredPointAsyncDAO();
+		this.reminderAsyncDAO = this.factory.getReminderAsyncDAO();
+		this.valueAsyncDAO = this.factory.getValueAsyncDAO();
+	}
 
 	@Override
 	public void saveOrUpdate(final ProjectDTO t, final AsyncCallback<ProjectDTO> callback, Transaction<Store> transaction) {

--- a/src/main/java/org/sigmah/offline/dao/ProjectModelAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/ProjectModelAsyncDAO.java
@@ -25,6 +25,7 @@ package org.sigmah.offline.dao;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.offline.indexeddb.ObjectStore;
 import org.sigmah.offline.indexeddb.Request;
 import org.sigmah.offline.indexeddb.Store;
@@ -46,17 +47,25 @@ import org.sigmah.shared.dto.element.FlexibleElementDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ProjectModelAsyncDAO extends AbstractUserDatabaseAsyncDAO<ProjectModelDTO, ProjectModelJS> {
 	
-	@Inject
+	
+
+	
 	private PhaseModelAsyncDAO phaseModelAsyncDAO;
 	
-	@Inject
+	
 	private ComputationAsyncDAO computationAsyncDAO;
+	
+	public ProjectModelAsyncDAO(ClientFactory factory) {
+		this.phaseModelAsyncDAO = factory.getPhaseModelAsyncDAO();
+		
+		this.computationAsyncDAO = factory.getComputationAsyncDAO();
+	}
 
 	/**
 	 * {@inheritDoc}
+	 * 
 	 */
 	@Override
 	public void saveOrUpdate(ProjectModelDTO t, AsyncCallback<ProjectModelDTO> callback, Transaction<Store> transaction) {

--- a/src/main/java/org/sigmah/offline/dao/ReminderAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/ReminderAsyncDAO.java
@@ -45,7 +45,6 @@ import org.sigmah.offline.indexeddb.Index;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ReminderAsyncDAO extends AbstractUserDatabaseAsyncDAO<ReminderDTO, ReminderJS> {
 
 	public void saveOrUpdate(final ReminderListDTO reminderListDTO, Transaction<Store> transaction) {

--- a/src/main/java/org/sigmah/offline/dao/TransfertAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/TransfertAsyncDAO.java
@@ -46,7 +46,7 @@ import org.sigmah.shared.file.TransfertType;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class TransfertAsyncDAO extends AbstractAsyncDAO<TransfertJS, Store> {
 
 	/**

--- a/src/main/java/org/sigmah/offline/dao/UpdateDiaryAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/UpdateDiaryAsyncDAO.java
@@ -47,7 +47,7 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class UpdateDiaryAsyncDAO extends AbstractUserDatabaseAsyncDAO<Command, CommandJS> {
 
 	public void saveWithNegativeId(final Command t, final AsyncCallback<Integer> callback) {

--- a/src/main/java/org/sigmah/offline/dao/UserAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/UserAsyncDAO.java
@@ -44,12 +44,10 @@ import com.allen_sauer.gwt.log.client.Log;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class UserAsyncDAO extends AbstractUserDatabaseAsyncDAO<UserDTO, UserJS> {
 
 	private final OrgUnitAsyncDAO orgUnitDAO;
 
-	@Inject
 	public UserAsyncDAO(OrgUnitAsyncDAO orgUnitDAO) {
 		this.orgUnitDAO = orgUnitDAO;
 	}

--- a/src/main/java/org/sigmah/offline/dao/UserUnitAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/UserUnitAsyncDAO.java
@@ -28,7 +28,7 @@ import org.sigmah.offline.indexeddb.Store;
 import org.sigmah.offline.js.UserUnitsResultJS;
 import org.sigmah.shared.command.result.UserUnitsResult;
 
-@Singleton
+
 public class UserUnitAsyncDAO extends AbstractUserDatabaseAsyncDAO<UserUnitsResult, UserUnitsResultJS> {
 
 	@Override

--- a/src/main/java/org/sigmah/offline/dao/ValueAsyncDAO.java
+++ b/src/main/java/org/sigmah/offline/dao/ValueAsyncDAO.java
@@ -54,11 +54,14 @@ import org.sigmah.shared.dto.element.FlexibleElementDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class ValueAsyncDAO extends BaseAsyncDAO<Store> {
 	
-	@Inject
 	private FileDataAsyncDAO fileDataAsyncDAO;
+	
+	public ValueAsyncDAO(FileDataAsyncDAO fileDataAsyncDAO) {
+		this.fileDataAsyncDAO = fileDataAsyncDAO;
+	}
 
 	/**
 	 * {@inheritDoc}

--- a/src/main/java/org/sigmah/offline/dispatch/LocalDispatchServiceAsync.java
+++ b/src/main/java/org/sigmah/offline/dispatch/LocalDispatchServiceAsync.java
@@ -44,7 +44,6 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (raphael.calabro@netapsys.fr)
  */
-@Singleton
 public class LocalDispatchServiceAsync implements SecureDispatchServiceAsync {
 	
 	public static final String LAST_USER_ITEM = "sigmah.last-user";

--- a/src/main/java/org/sigmah/offline/handler/ActivityCalendarAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/ActivityCalendarAsyncHandler.java
@@ -55,12 +55,11 @@ import com.google.inject.Singleton;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ActivityCalendarAsyncHandler implements AsyncCommandHandler<GetCalendar, Calendar> {
 
 	private final ProjectAsyncDAO projectAsyncDAO;
 
-	@Inject
+	
 	public ActivityCalendarAsyncHandler(ProjectAsyncDAO projectAsyncDAO) {
 		this.projectAsyncDAO = projectAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/CreateEntityAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/CreateEntityAsyncHandler.java
@@ -29,6 +29,8 @@ import com.google.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.DispatchListener;
 import org.sigmah.offline.dao.MonitoredPointAsyncDAO;
 import org.sigmah.offline.dao.PersonalCalendarAsyncDAO;
@@ -63,24 +65,28 @@ import org.sigmah.shared.dto.report.ProjectReportDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class CreateEntityAsyncHandler implements AsyncCommandHandler<CreateEntity, CreateResult>, DispatchListener<CreateEntity, CreateResult> {
 
-	@Inject
 	private UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
 
-	@Inject
 	private ProjectAsyncDAO projectAsyncDAO;
 	
-	@Inject
 	private PersonalCalendarAsyncDAO personalCalendarAsyncDAO;
 	
-	@Inject
 	private MonitoredPointAsyncDAO monitoredPointAsyncDAO;
 	
-	@Inject
 	private ReminderAsyncDAO reminderAsyncDAO;
 	
+	
+	
+	public CreateEntityAsyncHandler(ClientFactory factory) {
+		this.updateDiaryAsyncDAO = factory.getUpdateDiaryAsyncDAO();
+		this.projectAsyncDAO = factory.getProjectAsyncDAO();
+		this.personalCalendarAsyncDAO = factory.getPersonalCalendarAsyncDAO();
+		this.monitoredPointAsyncDAO = factory.getMonitoredPointAsyncDAO();
+		this.reminderAsyncDAO = factory.getReminderAsyncDAO();
+	}
+
 	@Override
 	public void execute(CreateEntity command, OfflineExecutionContext executionContext, final AsyncCallback<CreateResult> callback) {
 		executeCommand(command, null, executionContext.getAuthentication(), callback);

--- a/src/main/java/org/sigmah/offline/handler/DeleteAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/DeleteAsyncHandler.java
@@ -31,6 +31,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.DispatchListener;
 import org.sigmah.offline.dao.PersonalCalendarAsyncDAO;
 import org.sigmah.offline.dao.UpdateDiaryAsyncDAO;
@@ -59,25 +61,30 @@ import org.sigmah.shared.dto.value.ListableValue;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class DeleteAsyncHandler implements AsyncCommandHandler<Delete, VoidResult>, DispatchListener<Delete, VoidResult> {
 	
-	@Inject
+	
 	private UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
 	
-	@Inject
+
 	private ValueAsyncDAO valueAsyncDAO;
 	
-	@Inject
 	private PersonalCalendarAsyncDAO personalCalendarAsyncDAO;
 	
 	private final Map<String, String> entityNameMap;
+	
+	
 
-	public DeleteAsyncHandler() {
+	public DeleteAsyncHandler(ClientFactory factory) {
+		this.updateDiaryAsyncDAO = factory.getUpdateDiaryAsyncDAO();
+		this.valueAsyncDAO = factory.getValueAsyncDAO();
+		this.personalCalendarAsyncDAO = factory.getPersonalCalendarAsyncDAO();
 		entityNameMap = new HashMap<String, String>();
 		entityNameMap.put(FileDTO.ENTITY_NAME, FilesListElementDTO.ENTITY_NAME);
 		entityNameMap.put(FileVersionDTO.ENTITY_NAME, FilesListElementDTO.ENTITY_NAME);
 	}
+
 	
 	@Override
 	public void execute(final Delete command, OfflineExecutionContext executionContext, AsyncCallback<VoidResult> callback) {

--- a/src/main/java/org/sigmah/offline/handler/GetCalendarAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetCalendarAsyncHandler.java
@@ -25,6 +25,7 @@ package org.sigmah.offline.handler;
 import java.util.EnumMap;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.DispatchListener;
 import org.sigmah.offline.dispatch.AsyncCommandHandler;
 import org.sigmah.offline.dispatch.OfflineExecutionContext;
@@ -45,21 +46,17 @@ import org.sigmah.shared.command.result.Authentication;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetCalendarAsyncHandler implements AsyncCommandHandler<GetCalendar, Calendar>, DispatchListener<GetCalendar, Calendar> {
 
 	private final Map<CalendarType, AsyncCommandHandler<GetCalendar, Calendar>> calendarHandlers;
 
-	@Inject
-	public GetCalendarAsyncHandler(ActivityCalendarAsyncHandler activityCalendarAsyncHandler,
-			PersonalCalendarAsyncHandler personalCalendarAsyncHandler,
-			MonitoredPointCalendarAsyncHandler monitoredPointCalendarAsyncHandler,
-			ReminderCalendarAsyncHandler reminderCalendarAsyncHandler) {
+	
+	public GetCalendarAsyncHandler(ClientFactory factory) {
 		calendarHandlers = new EnumMap<CalendarType, AsyncCommandHandler<GetCalendar, Calendar>>(CalendarType.class);
-		calendarHandlers.put(CalendarType.Activity, activityCalendarAsyncHandler);
-		calendarHandlers.put(CalendarType.Personal, personalCalendarAsyncHandler);
-		calendarHandlers.put(CalendarType.MonitoredPoint, monitoredPointCalendarAsyncHandler);
-		calendarHandlers.put(CalendarType.Reminder, reminderCalendarAsyncHandler);
+		calendarHandlers.put(CalendarType.Activity, factory.getActivityCalendarAsyncHandler());
+		calendarHandlers.put(CalendarType.Personal, factory.getPersonalCalendarAsyncHandler());
+		calendarHandlers.put(CalendarType.MonitoredPoint, factory.getMonitoredPointCalendarAsyncHandler());
+		calendarHandlers.put(CalendarType.Reminder, factory.getReminderCalendarAsyncHandler());
 	}
 	
 	@Override

--- a/src/main/java/org/sigmah/offline/handler/GetCategoriesAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetCategoriesAsyncHandler.java
@@ -1,5 +1,7 @@
 package org.sigmah.offline.handler;
 
+import org.sigmah.client.ClientFactory;
+
 /*
  * #%L
  * Sigmah
@@ -41,14 +43,15 @@ import org.sigmah.shared.command.result.Authentication;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class GetCategoriesAsyncHandler implements AsyncCommandHandler<GetCategories, ListResult<CategoryTypeDTO>>, DispatchListener<GetCategories, ListResult<CategoryTypeDTO>> {
 
 	private final CategoryTypeAsyncDAO categoryTypeAsyncDAO;
 
-	@Inject
-	public GetCategoriesAsyncHandler(CategoryTypeAsyncDAO categoryTypeAsyncDAO) {
-		this.categoryTypeAsyncDAO = categoryTypeAsyncDAO;
+	
+	public GetCategoriesAsyncHandler(ClientFactory factory) {
+		this.categoryTypeAsyncDAO = factory.getCategoryTypeAsyncDAO();
+		
 	}
 	
 	/**

--- a/src/main/java/org/sigmah/offline/handler/GetCountriesAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetCountriesAsyncHandler.java
@@ -41,12 +41,12 @@ import org.sigmah.shared.command.result.Authentication;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class GetCountriesAsyncHandler implements AsyncCommandHandler<GetCountries, ListResult<CountryDTO>>, DispatchListener<GetCountries, ListResult<CountryDTO>> {
 
 	private final CountryAsyncDAO countryDAO;
 
-	@Inject
+	
 	public GetCountriesAsyncHandler(CountryAsyncDAO countryDAO) {
 		this.countryDAO = countryDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetCountryAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetCountryAsyncHandler.java
@@ -39,12 +39,12 @@ import org.sigmah.shared.dto.country.CountryDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class GetCountryAsyncHandler implements AsyncCommandHandler<GetCountry, CountryDTO>, DispatchListener<GetCountry, CountryDTO> {
 
 	private final CountryAsyncDAO countryDAO;
 
-	@Inject
+	
 	public GetCountryAsyncHandler(CountryAsyncDAO countryDAO) {
 		this.countryDAO = countryDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetHistoryAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetHistoryAsyncHandler.java
@@ -41,12 +41,10 @@ import org.sigmah.shared.command.result.Authentication;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetHistoryAsyncHandler implements AsyncCommandHandler<GetHistory, ListResult<HistoryTokenListDTO>>, DispatchListener<GetHistory, ListResult<HistoryTokenListDTO>> {
 
 	private final HistoryAsyncDAO historyAsyncDAO;
 
-	@Inject
 	public GetHistoryAsyncHandler(HistoryAsyncDAO historyAsyncDAO) {
 		this.historyAsyncDAO = historyAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetLinkedProjectsAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetLinkedProjectsAsyncHandler.java
@@ -40,12 +40,11 @@ import org.sigmah.shared.dto.ProjectFundingDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetLinkedProjectsAsyncHandler implements AsyncCommandHandler<GetLinkedProjects, ListResult<ProjectFundingDTO>> {
 
     private final ProjectAsyncDAO projectAsyncDAO;
 
-	@Inject
+
 	public GetLinkedProjectsAsyncHandler(ProjectAsyncDAO projectAsyncDAO) {
 		this.projectAsyncDAO = projectAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetMonitoredPointsAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetMonitoredPointsAsyncHandler.java
@@ -49,14 +49,21 @@ import org.sigmah.shared.dto.reminder.MonitoredPointDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetMonitoredPointsAsyncHandler implements AsyncCommandHandler<GetMonitoredPoints, ListResult<MonitoredPointDTO>>, DispatchListener<GetMonitoredPoints, ListResult<MonitoredPointDTO>> {
 	
-	@Inject
+	
 	private MonitoredPointAsyncDAO monitoredPointAsyncDAO;
 	
-	@Inject
+	
 	private ProjectAsyncDAO projectAsyncDAO;
+	
+	
+
+	public GetMonitoredPointsAsyncHandler(MonitoredPointAsyncDAO monitoredPointAsyncDAO,
+			ProjectAsyncDAO projectAsyncDAO) {
+		this.monitoredPointAsyncDAO = monitoredPointAsyncDAO;
+		this.projectAsyncDAO = projectAsyncDAO;
+	}
 
 	/**
 	 * {@inheritDoc}

--- a/src/main/java/org/sigmah/offline/handler/GetOrgUnitAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetOrgUnitAsyncHandler.java
@@ -40,12 +40,12 @@ import org.sigmah.shared.command.result.Authentication;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class GetOrgUnitAsyncHandler implements AsyncCommandHandler<GetOrgUnit, OrgUnitDTO>, DispatchListener<GetOrgUnit, OrgUnitDTO> {
 
 	private final OrgUnitAsyncDAO orgUnitAsyncDAO;
 
-	@Inject
+
 	public GetOrgUnitAsyncHandler(OrgUnitAsyncDAO orgUnitAsyncDAO) {
 		this.orgUnitAsyncDAO = orgUnitAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetOrgUnitsAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetOrgUnitsAsyncHandler.java
@@ -42,12 +42,10 @@ import org.sigmah.shared.dto.orgunit.OrgUnitDTO;
  * JavaScript implementation of {@link org.sigmah.server.handler.GetOrgUnitsHandler}.
  * Used when the user is offline.
  */
-@Singleton
 public class GetOrgUnitsAsyncHandler implements AsyncCommandHandler<GetOrgUnits, ListResult<OrgUnitDTO>>, DispatchListener<GetOrgUnits, ListResult<OrgUnitDTO>> {
 
 	private final OrgUnitAsyncDAO orgUnitAsyncDAO;
 
-	@Inject
 	public GetOrgUnitsAsyncHandler(OrgUnitAsyncDAO orgUnitAsyncDAO) {
 		this.orgUnitAsyncDAO = orgUnitAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetOrganizationAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetOrganizationAsyncHandler.java
@@ -40,12 +40,10 @@ import org.sigmah.shared.command.result.Authentication;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetOrganizationAsyncHandler implements AsyncCommandHandler<GetOrganization, OrganizationDTO>, DispatchListener<GetOrganization, OrganizationDTO> {
 
 	private final OrganizationAsyncDAO organizationDAO;
 
-	@Inject
 	public GetOrganizationAsyncHandler(OrganizationAsyncDAO organizationDAO) {
 		this.organizationDAO = organizationDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetProfilesAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetProfilesAsyncHandler.java
@@ -36,10 +36,16 @@ import org.sigmah.shared.dto.profile.ProfileDTO;
 
 public class GetProfilesAsyncHandler implements AsyncCommandHandler<GetProfiles, ListResult<ProfileDTO>>,
     DispatchListener<GetProfiles, ListResult<ProfileDTO>> {
-  @Inject
+ 
   ProfileAsyncDAO profileAsyncDAO;
+  
+  
 
-  @Override
+  public GetProfilesAsyncHandler(ProfileAsyncDAO profileAsyncDAO) {
+	this.profileAsyncDAO = profileAsyncDAO;
+}
+
+@Override
   public void execute(GetProfiles command, OfflineExecutionContext executionContext, final AsyncCallback<ListResult<ProfileDTO>> callback) {
     profileAsyncDAO.getListResult(callback);
   }

--- a/src/main/java/org/sigmah/offline/handler/GetProjectAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetProjectAsyncHandler.java
@@ -40,12 +40,10 @@ import org.sigmah.shared.dto.ProjectDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetProjectAsyncHandler implements AsyncCommandHandler<GetProject, ProjectDTO>, DispatchListener<GetProject, ProjectDTO> {
 
 	private final ProjectAsyncDAO projectAsyncDAO;
 
-	@Inject
 	public GetProjectAsyncHandler(ProjectAsyncDAO projectAsyncDAO) {
 		this.projectAsyncDAO = projectAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetProjectDocumentsAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetProjectDocumentsAsyncHandler.java
@@ -50,9 +50,15 @@ import org.sigmah.shared.dto.value.ListableValue;
 @Singleton
 public class GetProjectDocumentsAsyncHandler implements AsyncCommandHandler<GetProjectDocuments, ListResult<ReportReference>> {
 
-	@Inject
+	
 	private ValueAsyncDAO valueAsyncDAO;
 	
+	public GetProjectDocumentsAsyncHandler(ValueAsyncDAO valueAsyncDAO) {
+		this.valueAsyncDAO = valueAsyncDAO;
+	}
+
+
+
 	@Override
 	public void execute(GetProjectDocuments command, OfflineExecutionContext executionContext, AsyncCallback<ListResult<ReportReference>> callback) {
 		final ArrayList<ReportReference> references = new ArrayList<ReportReference>();

--- a/src/main/java/org/sigmah/offline/handler/GetProjectReportAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetProjectReportAsyncHandler.java
@@ -39,12 +39,16 @@ import org.sigmah.shared.dto.report.ProjectReportDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetProjectReportAsyncHandler implements AsyncCommandHandler<GetProjectReport, ProjectReportDTO>, DispatchListener<GetProjectReport, ProjectReportDTO> {
 
-	@Inject
 	private ProjectReportAsyncDAO projectReportAsyncDAO;
 	
+	
+	
+	public GetProjectReportAsyncHandler(ProjectReportAsyncDAO projectReportAsyncDAO) {
+		this.projectReportAsyncDAO = projectReportAsyncDAO;
+	}
+
 	@Override
 	public void execute(GetProjectReport command, OfflineExecutionContext executionContext, AsyncCallback<ProjectReportDTO> callback) {
 		projectReportAsyncDAO.get(command.getReportId(), callback);

--- a/src/main/java/org/sigmah/offline/handler/GetProjectReportsAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetProjectReportsAsyncHandler.java
@@ -40,12 +40,15 @@ import org.sigmah.shared.dto.report.ReportReference;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetProjectReportsAsyncHandler implements AsyncCommandHandler<GetProjectReports, ListResult<ReportReference>>, DispatchListener<GetProjectReports, ListResult<ReportReference>> {
 
-	@Inject
 	private ReportReferenceAsyncDAO reportReferenceAsyncDAO;
 	
+	
+	public GetProjectReportsAsyncHandler(ReportReferenceAsyncDAO reportReferenceAsyncDAO) {
+		this.reportReferenceAsyncDAO = reportReferenceAsyncDAO;
+	}
+
 	@Override
 	public void execute(GetProjectReports command, OfflineExecutionContext executionContext, AsyncCallback<ListResult<ReportReference>> callback) {
 		reportReferenceAsyncDAO.getAll(getParentId(command), callback);

--- a/src/main/java/org/sigmah/offline/handler/GetProjectTeamMembersAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetProjectTeamMembersAsyncHandler.java
@@ -42,7 +42,7 @@ public class GetProjectTeamMembersAsyncHandler implements AsyncCommandHandler<Ge
 
 	private final ProjectTeamMembersAsyncDAO projectTeamMembersAsyncDAO;
 
-	@Inject GetProjectTeamMembersAsyncHandler(ProjectTeamMembersAsyncDAO projectTeamMembersAsyncDAO) {
+	public GetProjectTeamMembersAsyncHandler(ProjectTeamMembersAsyncDAO projectTeamMembersAsyncDAO) {
 		this.projectTeamMembersAsyncDAO = projectTeamMembersAsyncDAO;
 	}
 

--- a/src/main/java/org/sigmah/offline/handler/GetProjectsAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetProjectsAsyncHandler.java
@@ -52,14 +52,12 @@ import org.sigmah.offline.dao.RequestManagerCallback;
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class GetProjectsAsyncHandler implements AsyncCommandHandler<GetProjects, ListResult<ProjectDTO>>, DispatchListener<GetProjects, ListResult<ProjectDTO>> {
 
 	private final Authentication authentication;
 	private final ProjectAsyncDAO projectAsyncDAO;
 	private final OrgUnitAsyncDAO orgUnitAsyncDAO;
 
-	@Inject
 	public GetProjectsAsyncHandler(Authentication authentication, ProjectAsyncDAO projectAsyncDAO, OrgUnitAsyncDAO orgUnitAsyncDAO) {
 		this.authentication = authentication;
 		this.projectAsyncDAO = projectAsyncDAO;

--- a/src/main/java/org/sigmah/offline/handler/GetProjectsFromIdAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetProjectsFromIdAsyncHandler.java
@@ -40,12 +40,10 @@ import com.google.inject.Singleton;
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-@Singleton
 public class GetProjectsFromIdAsyncHandler implements AsyncCommandHandler<GetProjectsFromId, ListResult<ProjectDTO>> {
 
 	private final ProjectAsyncDAO projectAsyncDAO;
 
-	@Inject
 	public GetProjectsFromIdAsyncHandler(ProjectAsyncDAO projectAsyncDAO) {
 		this.projectAsyncDAO = projectAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetRemindersAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetRemindersAsyncHandler.java
@@ -49,15 +49,19 @@ import org.sigmah.shared.dto.reminder.ReminderDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetRemindersAsyncHandler implements AsyncCommandHandler<GetReminders, ListResult<ReminderDTO>>, DispatchListener<GetReminders, ListResult<ReminderDTO>> {
 
-	@Inject
+
 	private ReminderAsyncDAO reminderAsyncDAO;
 
-	@Inject
+	
 	private ProjectAsyncDAO projectAsyncDAO;
 	
+	public GetRemindersAsyncHandler(ReminderAsyncDAO reminderAsyncDAO, ProjectAsyncDAO projectAsyncDAO) {
+		this.reminderAsyncDAO = reminderAsyncDAO;
+		this.projectAsyncDAO = projectAsyncDAO;
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/main/java/org/sigmah/offline/handler/GetUserUnitsByUserAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetUserUnitsByUserAsyncHandler.java
@@ -45,7 +45,7 @@ public class GetUserUnitsByUserAsyncHandler implements AsyncCommandHandler<GetUs
 
 	private final UserUnitAsyncDAO userUnitDAO;
 
-	@Inject GetUserUnitsByUserAsyncHandler(UserUnitAsyncDAO userUnitDAO) {
+	public GetUserUnitsByUserAsyncHandler(UserUnitAsyncDAO userUnitDAO) {
 		this.userUnitDAO = userUnitDAO;
 	}
 

--- a/src/main/java/org/sigmah/offline/handler/GetUsersByOrgUnitAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetUsersByOrgUnitAsyncHandler.java
@@ -45,8 +45,8 @@ public class GetUsersByOrgUnitAsyncHandler implements AsyncCommandHandler<GetUse
 	private final OrgUnitAsyncDAO orgUnitDAO;
 	private final UserAsyncDAO userDAO;
 
-	@Inject
-	GetUsersByOrgUnitAsyncHandler(OrgUnitAsyncDAO orgUnitDAO, UserAsyncDAO userDAO) {
+
+	public GetUsersByOrgUnitAsyncHandler(OrgUnitAsyncDAO orgUnitDAO, UserAsyncDAO userDAO) {
 		this.orgUnitDAO = orgUnitDAO;
 		this.userDAO = userDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetUsersByOrganizationAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetUsersByOrganizationAsyncHandler.java
@@ -41,12 +41,10 @@ import org.sigmah.shared.command.result.Authentication;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetUsersByOrganizationAsyncHandler implements AsyncCommandHandler<GetUsersByOrganization, ListResult<UserDTO>>, DispatchListener<GetUsersByOrganization, ListResult<UserDTO>> {
 
 	private final UserAsyncDAO userDAO;
 
-	@Inject
 	public GetUsersByOrganizationAsyncHandler(UserAsyncDAO userDAO) {
 		this.userDAO = userDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetValueAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetValueAsyncHandler.java
@@ -40,12 +40,10 @@ import org.sigmah.shared.command.result.Authentication;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class GetValueAsyncHandler implements AsyncCommandHandler<GetValue, ValueResult>, DispatchListener<GetValue, ValueResult> {
 	
 	private final ValueAsyncDAO valueAsyncDAO;
 
-	@Inject
 	public GetValueAsyncHandler(ValueAsyncDAO valueAsyncDAO) {
 		this.valueAsyncDAO = valueAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/GetValueFromLinkedProjectsAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/GetValueFromLinkedProjectsAsyncHandler.java
@@ -26,6 +26,8 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.offline.dao.ProjectAsyncDAO;
 import org.sigmah.offline.dao.RequestManager;
 import org.sigmah.offline.dao.RequestManagerCallback;
@@ -51,15 +53,20 @@ public class GetValueFromLinkedProjectsAsyncHandler implements AsyncCommandHandl
 	/**
 	 * Injected instance of {@link ProjectAsyncDAO}. 
 	 */
-	@Inject
+
 	private ProjectAsyncDAO projectAsyncDAO;
 	
 	/**
 	 * Injected instance of {@link ValueAsyncDAO}. 
 	 */
-	@Inject
+
 	private ValueAsyncDAO valueAsyncDAO;
 	
+	public GetValueFromLinkedProjectsAsyncHandler(ClientFactory factory) {
+		this.projectAsyncDAO = factory.getProjectAsyncDAO();
+		this.valueAsyncDAO = factory.getValueAsyncDAO();
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/main/java/org/sigmah/offline/handler/MonitoredPointCalendarAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/MonitoredPointCalendarAsyncHandler.java
@@ -49,12 +49,16 @@ import org.sigmah.shared.dto.reminder.MonitoredPointDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class MonitoredPointCalendarAsyncHandler implements AsyncCommandHandler<GetCalendar, Calendar> {
 
-	@Inject
+	
 	private MonitoredPointAsyncDAO monitoredPointAsyncDAO;
 	
+	
+	public MonitoredPointCalendarAsyncHandler(MonitoredPointAsyncDAO monitoredPointAsyncDAO) {
+		this.monitoredPointAsyncDAO = monitoredPointAsyncDAO;
+	}
+
 	@Override
 	public void execute(GetCalendar command, OfflineExecutionContext executionContext, final AsyncCallback<Calendar> callback) {
 		final MonitoredPointCalendarIdentifier identifier = (MonitoredPointCalendarIdentifier)command.getIdentifier();

--- a/src/main/java/org/sigmah/offline/handler/PersonalCalendarAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/PersonalCalendarAsyncHandler.java
@@ -41,12 +41,12 @@ import org.sigmah.shared.dto.calendar.PersonalCalendarIdentifier;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class PersonalCalendarAsyncHandler implements AsyncCommandHandler<GetCalendar, Calendar>, DispatchListener<GetCalendar, Calendar> {
 	
 	private final PersonalCalendarAsyncDAO personalCalendarAsyncDAO;
 
-	@Inject
+	
 	public PersonalCalendarAsyncHandler(PersonalCalendarAsyncDAO personalCalendarAsyncDAO) {
 		this.personalCalendarAsyncDAO = personalCalendarAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/PrepareFileUploadAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/PrepareFileUploadAsyncHandler.java
@@ -58,14 +58,19 @@ import org.sigmah.shared.util.ValueResultUtils;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class PrepareFileUploadAsyncHandler implements AsyncCommandHandler<PrepareFileUpload, FileVersionDTO> {
 	
-	@Inject
+
 	private ValueAsyncDAO valueAsyncDAO;
 	
-	@Inject
 	private UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
+	
+	
+
+	public PrepareFileUploadAsyncHandler(ValueAsyncDAO valueAsyncDAO, UpdateDiaryAsyncDAO updateDiaryAsyncDAO) {
+		this.valueAsyncDAO = valueAsyncDAO;
+		this.updateDiaryAsyncDAO = updateDiaryAsyncDAO;
+	}
 
 	@Override
 	public void execute(final PrepareFileUpload command, final OfflineExecutionContext executionContext, final AsyncCallback<FileVersionDTO> callback) {

--- a/src/main/java/org/sigmah/offline/handler/ReminderCalendarAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/ReminderCalendarAsyncHandler.java
@@ -49,11 +49,14 @@ import org.sigmah.shared.dto.reminder.ReminderDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ReminderCalendarAsyncHandler implements AsyncCommandHandler<GetCalendar, Calendar> {
 
-	@Inject
+	
 	private ReminderAsyncDAO reminderAsyncDAO;
+	
+	public ReminderCalendarAsyncHandler(ReminderAsyncDAO reminderAsyncDAO) {
+		this.reminderAsyncDAO = reminderAsyncDAO;
+	}
 	
 	@Override
 	public void execute(GetCalendar command, OfflineExecutionContext executionContext, final AsyncCallback<Calendar> callback) {

--- a/src/main/java/org/sigmah/offline/handler/SecureNavigationAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/SecureNavigationAsyncHandler.java
@@ -57,14 +57,17 @@ import org.sigmah.shared.dto.referential.PrivacyGroupPermissionEnum;
  *
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class SecureNavigationAsyncHandler implements AsyncCommandHandler<SecureNavigationCommand, SecureNavigationResult>, DispatchListener<SecureNavigationCommand, SecureNavigationResult> {
 
-	@Inject
 	private AuthenticationAsyncDAO authenticationAsyncDAO;
 
-	@Inject
 	private PageAccessAsyncDAO pageAccessAsyncDAO;
+
+	public SecureNavigationAsyncHandler(AuthenticationAsyncDAO authenticationAsyncDAO,
+			PageAccessAsyncDAO pageAccessAsyncDAO) {
+		this.authenticationAsyncDAO = authenticationAsyncDAO;
+		this.pageAccessAsyncDAO = pageAccessAsyncDAO;
+	}
 
 	@Override
 	public void execute(SecureNavigationCommand command, OfflineExecutionContext executionContext, AsyncCallback<SecureNavigationResult> callback) {

--- a/src/main/java/org/sigmah/offline/handler/UpdateEntityAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/UpdateEntityAsyncHandler.java
@@ -31,6 +31,8 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.computation.ClientValueResolver;
 import org.sigmah.client.dispatch.DispatchListener;
 import org.sigmah.offline.dao.ComputationAsyncDAO;
@@ -77,33 +79,40 @@ import org.sigmah.shared.dto.report.RichTextElementDTO;
  */
 public class UpdateEntityAsyncHandler implements AsyncCommandHandler<UpdateEntity, VoidResult>, DispatchListener<UpdateEntity, VoidResult> {
 
-	@Inject
 	private UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
-	
-	@Inject
+
 	private ProjectReportAsyncDAO projectReportAsyncDAO;
 	
-	@Inject
 	private PersonalCalendarAsyncDAO personalCalendarAsyncDAO;
 	
-	@Inject
 	private ReminderAsyncDAO reminderAsyncDAO;
 	
-	@Inject
 	private MonitoredPointAsyncDAO monitoredPointAsyncDAO;
 	
-	@Inject
+
 	private ProjectAsyncDAO projectAsyncDAO;
 	
-	@Inject
 	private ComputationAsyncDAO computationAsyncDAO;
 	
-	@Inject
+	
 	private ClientValueResolver valueResolver;
 	
-	@Inject
 	private ValueAsyncDAO valueAsyncDAO;
 	
+	
+	
+	public UpdateEntityAsyncHandler(ClientFactory factory) {
+		updateDiaryAsyncDAO = factory.getUpdateDiaryAsyncDAO();
+		projectAsyncDAO = factory.getProjectAsyncDAO();
+		personalCalendarAsyncDAO = factory.getPersonalCalendarAsyncDAO();
+		reminderAsyncDAO = factory.getReminderAsyncDAO();
+		monitoredPointAsyncDAO = factory.getMonitoredPointAsyncDAO();
+		projectAsyncDAO = factory.getProjectAsyncDAO();
+		computationAsyncDAO = factory.getComputationAsyncDAO();
+		valueResolver = factory.getClientValueResolver();
+		valueAsyncDAO = factory.getValueAsyncDAO();
+	}
+
 	@Override
 	public void execute(UpdateEntity command, OfflineExecutionContext executionContext, AsyncCallback<VoidResult> callback) {
 		executeCommand(command, executionContext.getAuthentication(), callback);

--- a/src/main/java/org/sigmah/offline/handler/UpdateLogFrameAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/UpdateLogFrameAsyncHandler.java
@@ -44,15 +44,19 @@ import org.sigmah.shared.dto.logframe.LogFrameDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class UpdateLogFrameAsyncHandler implements AsyncCommandHandler<UpdateLogFrame, LogFrameDTO>, DispatchListener<UpdateLogFrame, LogFrameDTO> {
 
-	@Inject
 	private ProjectAsyncDAO projectAsyncDAO;
 	
-	@Inject
 	private UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
 	
+	
+	
+	public UpdateLogFrameAsyncHandler(ProjectAsyncDAO projectAsyncDAO, UpdateDiaryAsyncDAO updateDiaryAsyncDAO) {
+		this.projectAsyncDAO = projectAsyncDAO;
+		this.updateDiaryAsyncDAO = updateDiaryAsyncDAO;
+	}
+
 	@Override
 	public void execute(final UpdateLogFrame command, OfflineExecutionContext executionContext, AsyncCallback<LogFrameDTO> callback) {
 		updateDiaryAsyncDAO.saveOrUpdate(command);

--- a/src/main/java/org/sigmah/offline/handler/UpdateMonitoredPointsAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/UpdateMonitoredPointsAsyncHandler.java
@@ -41,15 +41,22 @@ import org.sigmah.shared.dto.reminder.MonitoredPointDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class UpdateMonitoredPointsAsyncHandler implements AsyncCommandHandler<UpdateMonitoredPoints, ListResult<MonitoredPointDTO>>, DispatchListener<UpdateMonitoredPoints, ListResult<MonitoredPointDTO>> {
 
-	@Inject
+
 	private MonitoredPointAsyncDAO monitoredPointAsyncDAO;
 	
-	@Inject
+
 	private UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
 	
+	
+	
+	public UpdateMonitoredPointsAsyncHandler(MonitoredPointAsyncDAO monitoredPointAsyncDAO,
+			UpdateDiaryAsyncDAO updateDiaryAsyncDAO) {
+		this.monitoredPointAsyncDAO = monitoredPointAsyncDAO;
+		this.updateDiaryAsyncDAO = updateDiaryAsyncDAO;
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/main/java/org/sigmah/offline/handler/UpdateProjectAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/UpdateProjectAsyncHandler.java
@@ -42,6 +42,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.computation.ClientValueResolver;
 import org.sigmah.client.i18n.I18N;
 import org.sigmah.offline.dao.ComputationAsyncDAO;
@@ -66,25 +68,30 @@ import org.sigmah.shared.util.Collections;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class UpdateProjectAsyncHandler implements AsyncCommandHandler<UpdateProject, VoidResult>, DispatchListener<UpdateProject, VoidResult> {
 
-    @Inject
+
 	private ValueAsyncDAO valueAsyncDAO;
     
-    @Inject
 	private UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
     
-    @Inject
     private ProjectAsyncDAO projectAsyncDAO;
 	
-	@Inject
 	private ComputationAsyncDAO computationAsyncDAO;
 	
-	@Inject
 	private ClientValueResolver clientValueResolver;
+	
+	
 
-    /**
+    public UpdateProjectAsyncHandler(ClientFactory factory) {
+		this.valueAsyncDAO = factory.getValueAsyncDAO();
+		this.updateDiaryAsyncDAO = factory.getUpdateDiaryAsyncDAO();
+		this.projectAsyncDAO = factory.getProjectAsyncDAO();
+		this.computationAsyncDAO = factory.getComputationAsyncDAO();
+		this.clientValueResolver = factory.getClientValueResolver();
+	}
+
+	/**
      * {@inheritDoc}
      */
 	@Override

--- a/src/main/java/org/sigmah/offline/handler/UpdateProjectFavoriteAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/UpdateProjectFavoriteAsyncHandler.java
@@ -43,15 +43,19 @@ import org.sigmah.shared.dto.UserDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class UpdateProjectFavoriteAsyncHandler implements AsyncCommandHandler<UpdateProjectFavorite, CreateResult> {
 
-	@Inject
 	private ProjectAsyncDAO projectAsyncDAO;
 	
-	@Inject
 	private UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
 	
+	
+	
+	public UpdateProjectFavoriteAsyncHandler(ProjectAsyncDAO projectAsyncDAO, UpdateDiaryAsyncDAO updateDiaryAsyncDAO) {
+		this.projectAsyncDAO = projectAsyncDAO;
+		this.updateDiaryAsyncDAO = updateDiaryAsyncDAO;
+	}
+
 	@Override
 	public void execute(final UpdateProjectFavorite command, final OfflineExecutionContext executionContext, final AsyncCallback<CreateResult> callback) {
 		updateDiaryAsyncDAO.saveOrUpdate(command);

--- a/src/main/java/org/sigmah/offline/handler/UpdateProjectTeamMembersAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/UpdateProjectTeamMembersAsyncHandler.java
@@ -43,7 +43,7 @@ public class UpdateProjectTeamMembersAsyncHandler implements AsyncCommandHandler
 	private final ProjectTeamMembersAsyncDAO projectTeamMembersAsyncDAO;
 	private final UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
 
-	@Inject UpdateProjectTeamMembersAsyncHandler(ProjectTeamMembersAsyncDAO projectTeamMembersAsyncDAO, UpdateDiaryAsyncDAO updateDiaryAsyncDAO) {
+	public UpdateProjectTeamMembersAsyncHandler(ProjectTeamMembersAsyncDAO projectTeamMembersAsyncDAO, UpdateDiaryAsyncDAO updateDiaryAsyncDAO) {
 		this.projectTeamMembersAsyncDAO = projectTeamMembersAsyncDAO;
 		this.updateDiaryAsyncDAO = updateDiaryAsyncDAO;
 	}

--- a/src/main/java/org/sigmah/offline/handler/UpdateRemindersAsyncHandler.java
+++ b/src/main/java/org/sigmah/offline/handler/UpdateRemindersAsyncHandler.java
@@ -41,15 +41,18 @@ import org.sigmah.shared.dto.reminder.ReminderDTO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class UpdateRemindersAsyncHandler implements AsyncCommandHandler<UpdateReminders, ListResult<ReminderDTO>>, DispatchListener<UpdateReminders, ListResult<ReminderDTO>> {
 
-	@Inject
 	private ReminderAsyncDAO reminderAsyncDAO;
 	
-	@Inject
 	private UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
 	
+	
+	public UpdateRemindersAsyncHandler(ReminderAsyncDAO reminderAsyncDAO, UpdateDiaryAsyncDAO updateDiaryAsyncDAO) {
+		this.reminderAsyncDAO = reminderAsyncDAO;
+		this.updateDiaryAsyncDAO = updateDiaryAsyncDAO;
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/main/java/org/sigmah/offline/inject/OfflineModule.java
+++ b/src/main/java/org/sigmah/offline/inject/OfflineModule.java
@@ -1,192 +1,118 @@
 package org.sigmah.offline.inject;
 
-/*
- * #%L
- * Sigmah
- * %%
- * Copyright (C) 2010 - 2016 URD
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-3.0.html>.
- * #L%
- */
-
-import com.google.gwt.inject.client.AbstractGinModule;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
-
-import org.sigmah.client.dispatch.DispatchAsync;
-import org.sigmah.client.dispatch.DispatchListener;
-import org.sigmah.client.security.AuthenticationProvider;
-import org.sigmah.client.security.SecureDispatchAsync;
-import org.sigmah.offline.dispatch.AsyncCommandHandler;
-import org.sigmah.offline.dispatch.LocalDispatchServiceAsync;
-import org.sigmah.offline.handler.*;
-import org.sigmah.shared.command.*;
-import org.sigmah.shared.command.base.Command;
-import org.sigmah.shared.command.result.Result;
-
-import com.google.gwt.inject.client.AbstractGinModule;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
-import org.sigmah.offline.handler.BatchCommandAsyncHandler;
-import org.sigmah.offline.handler.CreateEntityAsyncHandler;
-import org.sigmah.offline.handler.DeleteAsyncHandler;
-import org.sigmah.offline.handler.GetLinkedProjectsAsyncHandler;
-import org.sigmah.offline.handler.GetProjectDocumentsAsyncHandler;
-import org.sigmah.offline.handler.GetProjectReportAsyncHandler;
-import org.sigmah.offline.handler.GetProjectReportsAsyncHandler;
-import org.sigmah.offline.handler.GetSitesCountAsyncHandler;
-import org.sigmah.offline.handler.GetValueFromLinkedProjectsAsyncHandler;
-import org.sigmah.offline.handler.UpdateEntityAsyncHandler;
-import org.sigmah.offline.handler.UpdateLogFrameAsyncHandler;
-import org.sigmah.offline.handler.UpdateMonitoredPointsAsyncHandler;
-import org.sigmah.offline.handler.UpdateProjectAsyncHandler;
-import org.sigmah.offline.handler.UpdateProjectFavoriteAsyncHandler;
-import org.sigmah.offline.handler.UpdateRemindersAsyncHandler;
-import org.sigmah.shared.command.BatchCommand;
-import org.sigmah.shared.command.CreateEntity;
-import org.sigmah.shared.command.Delete;
-import org.sigmah.shared.command.GetLinkedProjects;
-import org.sigmah.shared.command.GetProjectDocuments;
-import org.sigmah.shared.command.GetProjectReport;
-import org.sigmah.shared.command.GetProjectReports;
-import org.sigmah.shared.command.GetSitesCount;
-import org.sigmah.shared.command.GetValueFromLinkedProjects;
-import org.sigmah.shared.command.UpdateEntity;
-import org.sigmah.shared.command.UpdateLogFrame;
-import org.sigmah.shared.command.UpdateMonitoredPoints;
-import org.sigmah.shared.command.UpdateProject;
-import org.sigmah.shared.command.UpdateProjectFavorite;
-import org.sigmah.shared.command.UpdateReminders;
-import org.sigmah.shared.file.TransfertManager;
-import org.sigmah.shared.file.TransfertManagerProvider;
-
 /**
  *
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-public class OfflineModule extends AbstractGinModule {
+public class OfflineModule  {
 
-	private LocalDispatchServiceAsync localDispatchAsync;
-	private SecureDispatchAsync remoteDispatchAsync;
-	
-	@Override
-	protected void configure() {
-        bind(TransfertManager.class).toProvider(TransfertManagerProvider.class).in(Singleton.class);
-	}
-	
-	@Provides
-    protected LocalDispatchServiceAsync provideLocalDispatcher(DispatchAsync dispatchAsync, 
-			AuthenticationProvider authenticationProvider,
-			
-			// Injecting command handlers
-			BatchCommandAsyncHandler batchCommandAsyncHandler,
-			CreateEntityAsyncHandler createEntityAsyncHandler,
-			DeleteAsyncHandler deleteAsyncHandler,
-			GetCalendarAsyncHandler getCalendarAsyncHandler,
-			GetCategoriesAsyncHandler getCategoriesAsyncHandler,
-			GetCountriesAsyncHandler getCountriesAsyncHandler,
-			GetCountryAsyncHandler getCountryAsyncHandler,
-			GetHistoryAsyncHandler getHistoryAsyncHandler,
-            GetLinkedProjectsAsyncHandler getLinkedProjectsAsyncHandler,
-			GetMonitoredPointsAsyncHandler getMonitoredPointsAsyncHandler,
-			GetOrganizationAsyncHandler getOrganizationAsyncHandler,
-			GetOrgUnitAsyncHandler getOrgUnitAsyncHandler,
-		GetOrgUnitsAsyncHandler getOrgUnitsAsyncHandler,
-		GetProfilesAsyncHandler getProfilesAsyncHandler,
-			GetProjectAsyncHandler getProjectAsyncHandler,
-			GetProjectsAsyncHandler getProjectsAsyncHandler,
-			GetProjectsFromIdAsyncHandler getProjectsFromIdAsyncHandler,
-			GetProjectDocumentsAsyncHandler getProjectDocumentsAsyncHandler,
-			GetProjectReportAsyncHandler getProjectReportAsyncHandler,
-			GetProjectReportsAsyncHandler getProjectReportsAsyncHandler,
-			GetProjectTeamMembersAsyncHandler getProjectTeamMembersAsyncHandler,
-			GetRemindersAsyncHandler getRemindersAsyncHandler,
-			GetSitesCountAsyncHandler getSitesCountAsyncHandler,
-			GetUsersByOrganizationAsyncHandler getUsersByOrganizationAsyncHandler,
-			GetUsersByOrgUnitAsyncHandler getUsersByOrgUnitAsyncHandler,
-		GetUserUnitsByUserAsyncHandler getUserUnitsByUserAsyncHandler,
-			GetValueAsyncHandler getValueAsyncHandler,
-			GetValueFromLinkedProjectsAsyncHandler getValueFromLinkedProjectsAsyncHandler,
-            PrepareFileUploadAsyncHandler prepareFileUploadAsyncHandler,
-			SecureNavigationAsyncHandler secureNavigationAsyncHandler,
-			UpdateEntityAsyncHandler updateEntityAsyncHandler,
-			UpdateLogFrameAsyncHandler updateLogFrameAsyncHandler,
-			UpdateMonitoredPointsAsyncHandler updateMonitoredPointsAsyncHandler,
-			UpdateProjectAsyncHandler updateProjectAsyncHandler,
-			UpdateProjectFavoriteAsyncHandler updateProjectFavoriteAsyncHandler,
-			UpdateProjectTeamMembersAsyncHandler updateProjectTeamMembersAsyncHandler,
-			UpdateRemindersAsyncHandler updateRemindersAsyncHandler) {
-		
-		localDispatchAsync = new LocalDispatchServiceAsync(authenticationProvider);
-		if(dispatchAsync instanceof SecureDispatchAsync) {
-			remoteDispatchAsync = (SecureDispatchAsync) dispatchAsync;
-			remoteDispatchAsync.setOfflineService(localDispatchAsync);
-		} else {
-			throw new IllegalArgumentException("Given DispatchAsync type is not supported (SecureDispatchAsync is required).");
-		}
-		
-		batchCommandAsyncHandler.setDispatcher(localDispatchAsync);
-		
-        registerHandler(BatchCommand.class, batchCommandAsyncHandler);
-        registerHandler(CreateEntity.class, createEntityAsyncHandler);
-        registerHandler(Delete.class, deleteAsyncHandler);
-        registerHandler(GetCalendar.class, getCalendarAsyncHandler);
-        registerHandler(GetCategories.class, getCategoriesAsyncHandler);
-        registerHandler(GetCountries.class, getCountriesAsyncHandler);
-        registerHandler(GetCountry.class, getCountryAsyncHandler);
-        registerHandler(GetHistory.class, getHistoryAsyncHandler);
-        registerHandler(GetLinkedProjects.class, getLinkedProjectsAsyncHandler);
-        registerHandler(GetMonitoredPoints.class, getMonitoredPointsAsyncHandler);
-        registerHandler(GetOrganization.class, getOrganizationAsyncHandler);
-        registerHandler(GetOrgUnit.class, getOrgUnitAsyncHandler);
-		registerHandler(GetOrgUnits.class, getOrgUnitsAsyncHandler);
-		registerHandler(GetProfiles.class, getProfilesAsyncHandler);
-        registerHandler(GetProject.class, getProjectAsyncHandler);
-        registerHandler(GetProjects.class, getProjectsAsyncHandler);
-        registerHandler(GetProjectsFromId.class, getProjectsFromIdAsyncHandler);
-        registerHandler(GetProjectDocuments.class, getProjectDocumentsAsyncHandler);
-        registerHandler(GetProjectReport.class, getProjectReportAsyncHandler);
-        registerHandler(GetProjectReports.class, getProjectReportsAsyncHandler);
-		registerHandler(GetProjectTeamMembers.class, getProjectTeamMembersAsyncHandler);
-        registerHandler(GetReminders.class, getRemindersAsyncHandler);
-        registerHandler(GetSitesCount.class, getSitesCountAsyncHandler);
-        registerHandler(GetUsersByOrganization.class, getUsersByOrganizationAsyncHandler);
-		registerHandler(GetUsersByOrgUnit.class, getUsersByOrgUnitAsyncHandler);
-		registerHandler(GetUserUnitsByUser.class, getUserUnitsByUserAsyncHandler);
-        registerHandler(GetValue.class, getValueAsyncHandler);
-        registerHandler(GetValueFromLinkedProjects.class, getValueFromLinkedProjectsAsyncHandler);
-		registerHandler(PrepareFileUpload.class, prepareFileUploadAsyncHandler);
-        registerHandler(SecureNavigationCommand.class, secureNavigationAsyncHandler);
-        registerHandler(UpdateEntity.class, updateEntityAsyncHandler);
-        registerHandler(UpdateLogFrame.class, updateLogFrameAsyncHandler);
-		registerHandler(UpdateMonitoredPoints.class, updateMonitoredPointsAsyncHandler);
-        registerHandler(UpdateProject.class, updateProjectAsyncHandler);
-        registerHandler(UpdateProjectFavorite.class, updateProjectFavoriteAsyncHandler);
-		registerHandler(UpdateReminders.class, updateRemindersAsyncHandler);
-		registerHandler(UpdateProjectTeamMembers.class, updateProjectTeamMembersAsyncHandler);
-				
-        return localDispatchAsync;
-	}
-	
-	private <C extends Command<R>, R extends Result> void registerHandler(Class<C> commandClass, AsyncCommandHandler<C, R> handler) {
-		localDispatchAsync.registerHandler(commandClass, handler);
-		
-		if(handler instanceof DispatchListener) {
-			final DispatchListener<C, R> listener = (DispatchListener<C, R>)handler;
-			remoteDispatchAsync.registerListener(commandClass, listener);
-		}
-	}
+//	private LocalDispatchServiceAsync localDispatchAsync;
+//	private SecureDispatchAsync remoteDispatchAsync;
+//	
+//	@Override
+//	protected void configure() {
+//        bind(TransfertManager.class).toProvider(TransfertManagerProvider.class).in(Singleton.class);
+//	}
+//	
+//    protected LocalDispatchServiceAsync provideLocalDispatcher(DispatchAsync dispatchAsync, 
+//			AuthenticationProvider authenticationProvider,
+//			
+//			// Injecting command handlers
+//			BatchCommandAsyncHandler batchCommandAsyncHandler,
+//			CreateEntityAsyncHandler createEntityAsyncHandler,
+//			DeleteAsyncHandler deleteAsyncHandler,
+//			GetCalendarAsyncHandler getCalendarAsyncHandler,
+//			GetCategoriesAsyncHandler getCategoriesAsyncHandler,
+//			GetCountriesAsyncHandler getCountriesAsyncHandler,
+//			GetCountryAsyncHandler getCountryAsyncHandler,
+//			GetHistoryAsyncHandler getHistoryAsyncHandler,
+//            GetLinkedProjectsAsyncHandler getLinkedProjectsAsyncHandler,
+//			GetMonitoredPointsAsyncHandler getMonitoredPointsAsyncHandler,
+//			GetOrganizationAsyncHandler getOrganizationAsyncHandler,
+//			GetOrgUnitAsyncHandler getOrgUnitAsyncHandler,
+//		GetOrgUnitsAsyncHandler getOrgUnitsAsyncHandler,
+//		GetProfilesAsyncHandler getProfilesAsyncHandler,
+//			GetProjectAsyncHandler getProjectAsyncHandler,
+//			GetProjectsAsyncHandler getProjectsAsyncHandler,
+//			GetProjectsFromIdAsyncHandler getProjectsFromIdAsyncHandler,
+//			GetProjectDocumentsAsyncHandler getProjectDocumentsAsyncHandler,
+//			GetProjectReportAsyncHandler getProjectReportAsyncHandler,
+//			GetProjectReportsAsyncHandler getProjectReportsAsyncHandler,
+//			GetProjectTeamMembersAsyncHandler getProjectTeamMembersAsyncHandler,
+//			GetRemindersAsyncHandler getRemindersAsyncHandler,
+//			GetSitesCountAsyncHandler getSitesCountAsyncHandler,
+//			GetUsersByOrganizationAsyncHandler getUsersByOrganizationAsyncHandler,
+//			GetUsersByOrgUnitAsyncHandler getUsersByOrgUnitAsyncHandler,
+//		GetUserUnitsByUserAsyncHandler getUserUnitsByUserAsyncHandler,
+//			GetValueAsyncHandler getValueAsyncHandler,
+//			GetValueFromLinkedProjectsAsyncHandler getValueFromLinkedProjectsAsyncHandler,
+//            PrepareFileUploadAsyncHandler prepareFileUploadAsyncHandler,
+//			SecureNavigationAsyncHandler secureNavigationAsyncHandler,
+//			UpdateEntityAsyncHandler updateEntityAsyncHandler,
+//			UpdateLogFrameAsyncHandler updateLogFrameAsyncHandler,
+//			UpdateMonitoredPointsAsyncHandler updateMonitoredPointsAsyncHandler,
+//			UpdateProjectAsyncHandler updateProjectAsyncHandler,
+//			UpdateProjectFavoriteAsyncHandler updateProjectFavoriteAsyncHandler,
+//			UpdateProjectTeamMembersAsyncHandler updateProjectTeamMembersAsyncHandler,
+//			UpdateRemindersAsyncHandler updateRemindersAsyncHandler) {
+//		
+//		localDispatchAsync = new LocalDispatchServiceAsync(authenticationProvider);
+//		if(dispatchAsync instanceof SecureDispatchAsync) {
+//			remoteDispatchAsync = (SecureDispatchAsync) dispatchAsync;
+//			remoteDispatchAsync.setOfflineService(localDispatchAsync);
+//		} else {
+//			throw new IllegalArgumentException("Given DispatchAsync type is not supported (SecureDispatchAsync is required).");
+//		}
+//		
+//		batchCommandAsyncHandler.setDispatcher(localDispatchAsync);
+//		
+//        registerHandler(BatchCommand.class, batchCommandAsyncHandler);
+//        registerHandler(CreateEntity.class, createEntityAsyncHandler);
+//        registerHandler(Delete.class, deleteAsyncHandler);
+//        registerHandler(GetCalendar.class, getCalendarAsyncHandler);
+//        registerHandler(GetCategories.class, getCategoriesAsyncHandler);
+//        registerHandler(GetCountries.class, getCountriesAsyncHandler);
+//        registerHandler(GetCountry.class, getCountryAsyncHandler);
+//        registerHandler(GetHistory.class, getHistoryAsyncHandler);
+//        registerHandler(GetLinkedProjects.class, getLinkedProjectsAsyncHandler);
+//        registerHandler(GetMonitoredPoints.class, getMonitoredPointsAsyncHandler);
+//        registerHandler(GetOrganization.class, getOrganizationAsyncHandler);
+//        registerHandler(GetOrgUnit.class, getOrgUnitAsyncHandler);
+//		registerHandler(GetOrgUnits.class, getOrgUnitsAsyncHandler);
+//		registerHandler(GetProfiles.class, getProfilesAsyncHandler);
+//        registerHandler(GetProject.class, getProjectAsyncHandler);
+//        registerHandler(GetProjects.class, getProjectsAsyncHandler);
+//        registerHandler(GetProjectsFromId.class, getProjectsFromIdAsyncHandler);
+//        registerHandler(GetProjectDocuments.class, getProjectDocumentsAsyncHandler);
+//        registerHandler(GetProjectReport.class, getProjectReportAsyncHandler);
+//        registerHandler(GetProjectReports.class, getProjectReportsAsyncHandler);
+//		registerHandler(GetProjectTeamMembers.class, getProjectTeamMembersAsyncHandler);
+//        registerHandler(GetReminders.class, getRemindersAsyncHandler);
+//        registerHandler(GetSitesCount.class, getSitesCountAsyncHandler);
+//        registerHandler(GetUsersByOrganization.class, getUsersByOrganizationAsyncHandler);
+//		registerHandler(GetUsersByOrgUnit.class, getUsersByOrgUnitAsyncHandler);
+//		registerHandler(GetUserUnitsByUser.class, getUserUnitsByUserAsyncHandler);
+//        registerHandler(GetValue.class, getValueAsyncHandler);
+//        registerHandler(GetValueFromLinkedProjects.class, getValueFromLinkedProjectsAsyncHandler);
+//		registerHandler(PrepareFileUpload.class, prepareFileUploadAsyncHandler);
+//        registerHandler(SecureNavigationCommand.class, secureNavigationAsyncHandler);
+//        registerHandler(UpdateEntity.class, updateEntityAsyncHandler);
+//        registerHandler(UpdateLogFrame.class, updateLogFrameAsyncHandler);
+//		registerHandler(UpdateMonitoredPoints.class, updateMonitoredPointsAsyncHandler);
+//        registerHandler(UpdateProject.class, updateProjectAsyncHandler);
+//        registerHandler(UpdateProjectFavorite.class, updateProjectFavoriteAsyncHandler);
+//		registerHandler(UpdateReminders.class, updateRemindersAsyncHandler);
+//		registerHandler(UpdateProjectTeamMembers.class, updateProjectTeamMembersAsyncHandler);
+//				
+//        return localDispatchAsync;
+//	}
+//	
+//	private <C extends Command<R>, R extends Result> void registerHandler(Class<C> commandClass, AsyncCommandHandler<C, R> handler) {
+//		localDispatchAsync.registerHandler(commandClass, handler);
+//		
+//		if(handler instanceof DispatchListener) {
+//			final DispatchListener<C, R> listener = (DispatchListener<C, R>)handler;
+//			remoteDispatchAsync.registerListener(commandClass, listener);
+//		}
+//	}
 }

--- a/src/main/java/org/sigmah/offline/presenter/FileSelectionPresenter.java
+++ b/src/main/java/org/sigmah/offline/presenter/FileSelectionPresenter.java
@@ -35,6 +35,8 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
 import java.util.List;
+
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.dispatch.CommandResultHandler;
 import org.sigmah.client.dispatch.monitor.LoadingMask;
 import org.sigmah.client.i18n.I18N;
@@ -77,7 +79,6 @@ public class FileSelectionPresenter extends AbstractPagePresenter<FileSelectionP
 	/**
 	 * Description of the view managed by this presenter.
 	 */
-	@ImplementedBy(FileSelectionView.class)
 	public static interface View extends ViewPopupInterface {
 		
 		TreeGrid<TreeGridFileModel> getUploadGrid();
@@ -101,16 +102,14 @@ public class FileSelectionPresenter extends AbstractPagePresenter<FileSelectionP
 		
 	}
 	
-	@Inject
+
 	private TransfertAsyncDAO transfertAsyncDAO;
 	
-	@Inject
+
 	private ProjectAsyncDAO projectAsyncDAO;
 	
-	@Inject
 	private OrgUnitAsyncDAO orgUnitAsyncDAO;
 	
-	@Inject
 	private TransfertManager transfertManager;
 	
 	/**
@@ -118,12 +117,15 @@ public class FileSelectionPresenter extends AbstractPagePresenter<FileSelectionP
 	 * 
 	 * @param view
 	 *          The view managed by the presenter.
-	 * @param injector
+	 * @param factory
 	 *          The application injector.
 	 */
-	@Inject
-	protected FileSelectionPresenter(final View view, final Injector injector) {
-		super(view, injector);
+	public FileSelectionPresenter(final View view, final ClientFactory factory) {
+		super(view, factory);
+		this.transfertAsyncDAO = factory.getTransfertAsyncDAO();
+		this.projectAsyncDAO = factory.getProjectAsyncDAO();
+		this.orgUnitAsyncDAO = factory.getOrgUnitAsyncDAO();
+		this.transfertManager = factory.getTransfertManager();
 	}
 	
 	@Override

--- a/src/main/java/org/sigmah/offline/status/ApplicationStateManager.java
+++ b/src/main/java/org/sigmah/offline/status/ApplicationStateManager.java
@@ -51,7 +51,6 @@ import org.sigmah.offline.dao.UpdateDiaryAsyncDAO;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
 public class ApplicationStateManager implements OfflineEvent.Source {
 	
 	public static final int NETWORK_POLLING_INTERVAL = 3000;
@@ -82,7 +81,7 @@ public class ApplicationStateManager implements OfflineEvent.Source {
 	 */
 	private Runnable onReconnection;
 	
-	@Inject
+
 	public ApplicationStateManager(EventBus eventBus, UpdateDiaryAsyncDAO updateDiaryAsyncDAO) {
 		this.eventBus = eventBus;
 		this.updateDiaryAsyncDAO = updateDiaryAsyncDAO;

--- a/src/main/java/org/sigmah/offline/status/ConnectionStatus.java
+++ b/src/main/java/org/sigmah/offline/status/ConnectionStatus.java
@@ -52,7 +52,6 @@ import org.sigmah.offline.sync.Synchronizer;
  * @author Raphaël Calabro <rcalabro@ideia.fr>
  */
 @Deprecated
-@Singleton
 public class ConnectionStatus {
 	/**
 	 * Listener interface. Called immediately on add and after every status 
@@ -69,7 +68,7 @@ public class ConnectionStatus {
 	private final List<Listener> listeners;
 	private final Timer timer;
 
-	@Inject
+	
 	public ConnectionStatus(EventBus eventBus, Synchronizer synchronizer) {
 		this.online = getInitialStatus();
         this.state = online ? ApplicationState.ONLINE : ApplicationState.OFFLINE;

--- a/src/main/java/org/sigmah/offline/sync/Synchronizer.java
+++ b/src/main/java/org/sigmah/offline/sync/Synchronizer.java
@@ -79,7 +79,7 @@ import org.sigmah.shared.dto.report.ReportReference;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-@Singleton
+
 public class Synchronizer {
     
     private static final double ACCESS_RIGHTS_VALUE = 0.05;
@@ -88,28 +88,35 @@ public class Synchronizer {
     private static final double ORGUNIT_DETAIL_VALUE = 0.3;
     private static final double PROJECT_DETAIL_VALUE = 0.5;
     
-    @Inject
 	private UpdateDiaryAsyncDAO updateDiaryAsyncDAO;
 	
-	@Inject
 	private ReminderAsyncDAO reminderAsyncDAO;
     
-	@Inject
 	private MonitoredPointAsyncDAO monitoredPointAsyncDAO;
 	
-	@Inject
 	private TransfertAsyncDAO transfertAsyncDAO;
 	
-	@Inject
 	private FileDataAsyncDAO fileDataAsyncDAO;
     
-    @Inject
 	private DispatchAsync dispatcher;
 	
-	@Inject
 	private OrgUnitAsyncDAO orgUnitAsyncDAO;
 	
-    /**
+
+	
+    public Synchronizer(UpdateDiaryAsyncDAO updateDiaryAsyncDAO, ReminderAsyncDAO reminderAsyncDAO,
+			MonitoredPointAsyncDAO monitoredPointAsyncDAO, TransfertAsyncDAO transfertAsyncDAO,
+			FileDataAsyncDAO fileDataAsyncDAO, DispatchAsync dispatcher, OrgUnitAsyncDAO orgUnitAsyncDAO) {
+		this.updateDiaryAsyncDAO = updateDiaryAsyncDAO;
+		this.reminderAsyncDAO = reminderAsyncDAO;
+		this.monitoredPointAsyncDAO = monitoredPointAsyncDAO;
+		this.transfertAsyncDAO = transfertAsyncDAO;
+		this.fileDataAsyncDAO = fileDataAsyncDAO;
+		this.dispatcher = dispatcher;
+		this.orgUnitAsyncDAO = orgUnitAsyncDAO;
+	}
+
+	/**
 	 * Send to the server the modifications done offline.
 	 * 
 	 * @param callback Callback called when the push is finished or when an error occured.

--- a/src/main/java/org/sigmah/shared/file/DirectTransfertManager.java
+++ b/src/main/java/org/sigmah/shared/file/DirectTransfertManager.java
@@ -48,7 +48,7 @@ import org.sigmah.shared.util.FileType;
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  * @author Denis Colliot (dcolliot@ideia.fr)
  */
-class DirectTransfertManager implements TransfertManager {
+public class DirectTransfertManager implements TransfertManager {
 
 	private final AuthenticationProvider authenticationProvider;
 	private final PageManager pageManager;

--- a/src/main/java/org/sigmah/shared/file/Html5TransfertManager.java
+++ b/src/main/java/org/sigmah/shared/file/Html5TransfertManager.java
@@ -71,7 +71,7 @@ import org.sigmah.offline.fileapi.Files;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-class Html5TransfertManager implements TransfertManager, HasProgressListeners {
+public class Html5TransfertManager implements TransfertManager, HasProgressListeners {
 	
 	/**
 	 * Size in bytes of the first slice.

--- a/src/main/java/org/sigmah/shared/file/TransfertManagerProvider.java
+++ b/src/main/java/org/sigmah/shared/file/TransfertManagerProvider.java
@@ -1,5 +1,15 @@
 package org.sigmah.shared.file;
 
+import org.sigmah.client.dispatch.DispatchAsync;
+import org.sigmah.client.event.EventBus;
+import org.sigmah.client.page.PageManager;
+import org.sigmah.client.security.AuthenticationProvider;
+import org.sigmah.client.util.ClientUtils;
+import org.sigmah.offline.dao.FileDataAsyncDAO;
+import org.sigmah.offline.dao.TransfertAsyncDAO;
+import org.sigmah.offline.fileapi.FileReader;
+import org.sigmah.offline.indexeddb.IndexedDB;
+
 /*
  * #%L
  * Sigmah
@@ -23,18 +33,6 @@ package org.sigmah.shared.file;
  */
 
 import com.google.gwt.core.client.GWT;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-import org.sigmah.client.dispatch.DispatchAsync;
-import org.sigmah.client.event.EventBus;
-import org.sigmah.client.page.PageManager;
-import org.sigmah.client.security.AuthenticationProvider;
-import org.sigmah.client.util.ClientUtils;
-import org.sigmah.offline.dao.FileDataAsyncDAO;
-import org.sigmah.offline.dao.TransfertAsyncDAO;
-import org.sigmah.offline.fileapi.FileReader;
-import org.sigmah.offline.indexeddb.IndexedDB;
-import org.sigmah.offline.status.ConnectionStatus;
 
 /**
  * Maintain and provides a TransfertManager singleton.
@@ -43,7 +41,7 @@ import org.sigmah.offline.status.ConnectionStatus;
  * 
  * @author Raphaël Calabro (rcalabro@ideia.fr)
  */
-public class TransfertManagerProvider implements Provider<TransfertManager> {
+public class TransfertManagerProvider  {
     
     /**
      * Activates HTML5 engine if the current browser supports downloads from a 
@@ -61,7 +59,6 @@ public class TransfertManagerProvider implements Provider<TransfertManager> {
 
     private final TransfertManager transfertManager;
 
-    @Inject
     public TransfertManagerProvider(DispatchAsync dispatchAsync, AuthenticationProvider authenticationProvider, PageManager pageManager, EventBus eventBus, FileDataAsyncDAO fileDataAsyncDAO, TransfertAsyncDAO transfertAsyncDAO) {
       DirectTransfertManager directTransfertManager = new DirectTransfertManager(authenticationProvider, pageManager, eventBus);
       if (html5EngineActive && IndexedDB.isSupported() && FileReader.isSupported()) {
@@ -71,7 +68,7 @@ public class TransfertManagerProvider implements Provider<TransfertManager> {
       }
     }
 
-    @Override
+
     public TransfertManager get() {
         return transfertManager;
     }

--- a/src/main/java/org/sigmah/shared/servlet/ServletRequestBuilder.java
+++ b/src/main/java/org/sigmah/shared/servlet/ServletRequestBuilder.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.sigmah.client.ClientFactory;
 import org.sigmah.client.inject.Injector;
 import org.sigmah.client.page.RequestParameter;
 import org.sigmah.client.util.ClientUtils;
@@ -102,9 +103,9 @@ public final class ServletRequestBuilder {
 	 * @param method
 	 *          The servlet method to execute.
 	 */
-	public ServletRequestBuilder(final Injector injector, final Method requestMethod, final Servlet servlet, final ServletMethod method) {
+	public ServletRequestBuilder(final ClientFactory factory, final Method requestMethod, final Servlet servlet, final ServletMethod method) {
 		this.requestMethod = requestMethod;
-		this.urlBuilder = new ServletUrlBuilder(injector.getAuthenticationProvider(), injector.getPageManager(), servlet, method);
+		this.urlBuilder = new ServletUrlBuilder(factory.getAuthenticationProvider(), factory.getPageManager(), servlet, method);
 		this.requestAttributes = new HashMap<String, String>();
 		this.urlBuilder.addParameter(ServletConstants.AJAX, ClientUtils.toList(true));
 	}

--- a/src/main/resources/org/sigmah/Sigmah.gwt.xml
+++ b/src/main/resources/org/sigmah/Sigmah.gwt.xml
@@ -41,8 +41,6 @@
 	<set-configuration-property name="log_pattern" value="[%-5p] {%d{yyyy/MM/dd HH:mm:ss.SSS}} %C - %m%n" />
 	<set-property name="log_DivLogger" value="DISABLED" />
 
-	<!-- GIN (Google INjector) -->
-	<inherits name="com.google.gwt.inject.Inject" />
 	
 	<!-- Maps (Google Maps and OpenStreetMaps) -->
 	<inherits name="com.google.gwt.maps.GoogleMaps" />
@@ -50,6 +48,10 @@
 
 	<!-- Reduce the compilation time by creating permutations for specific browsers. -->
 	<!-- <set-property name="user.agent" value="safari,gecko1_8" /> - FF only (available values: ie8, gecko1_8, safari, ie9, ie10). -->
+	
+	<replace-with class="org.sigmah.client.ClientFactoryImpl">
+    <when-type-is class="org.sigmah.client.ClientFactory"/>
+   </replace-with>
 
 	<!-- Default locale. -->
 	<extend-property name="locale" values="fr,en_GB,es" />


### PR DESCRIPTION
GIN is outdated and not maintained anymore and it's near its end of life. It also causes Null pointer exceptions during dev mode. It's better not to not use it, and replace by a a simple interface (Client factory) that implements all the dependency injection of the project, and use deffered binding instead.
 This PR removes all the GIN (@Inject, @Singelton,..) DI classes and and annotations and replaces it by a manual DI mechanism implemented in ClassFactory and ClassFactoryImpl. it also removes the GIN dependency from the pom.xml. The project has been tested after the changes and it launches much faster during Dev mode. 