### PR TITLE
809: Email created from "Report a bug" hyperlink : free from + signs

### DIFF
--- a/src/main/java/org/sigmah/client/util/ClientUtils.java
+++ b/src/main/java/org/sigmah/client/util/ClientUtils.java
@@ -1644,11 +1644,11 @@ public final class ClientUtils {
 		mailTos.deleteCharAt(mailTos.length() - 1);
 		if (isNotBlank(subject)) {
 			mailTos.append("?subject=");
-			mailTos.append(URL.encodeQueryString(subject));
+			mailTos.append(subject);
 		}
 		if (isNotBlank(body)) {
 			mailTos.append((isNotBlank(subject) ? "&" : "?") + "body=");
-			mailTos.append(URL.encodeQueryString(body));
+			mailTos.append(body);
 		}
 
 		Window.Location.assign(mailTos.toString());


### PR DESCRIPTION
These strings were encoded using URL.encodeQueryString() which causes spaces to be replaced with + signs. This pull request removes this and directly add the string to mail object. 
fixes 809.